### PR TITLE
Os app killswitch conan qt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "openstudio"]
 	path = openstudio
-	url = git@github.com:jmarrec/OpenStudio.git
+	url = git@github.com:NREL/OpenStudio.git
 	branch = OS_App_killswitch_Qt
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "openstudio"]
 	path = openstudio
-	url = git@github.com:nrel/OpenStudio.git
-	branch = OS_App_killswitch_Packaging
+	url = git@github.com:jmarrec/OpenStudio.git
+	branch = OS_App_killswitch_Qt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,12 +297,13 @@ endif()
 # Required dependencies
 
 # Threading library
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
 find_package(Threads)
 if(UNIX)
   set(CMAKE_THREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}" CACHE STRING "Thread library used.")
   mark_as_advanced(CMAKE_THREAD_LIBS)
 endif()
-
 
 # Qt via conan
 list(APPEND CONAN_OPTIONS "qt:commercial=False") # opensource
@@ -582,6 +583,11 @@ endif()
 
 # CPack: TODO
 
+# TODO: There's a lot of packaging stuff that needs to be done still, and most of it is still in openstudio(core) while it relates to OpenStudioApp and needs to be moved.
+# This is the case for the CPACK_DEBIAN_PACKAGE_DEPENDS for eg: the libwxgtk3 stuff is definitely OS App related
+# We built against shared Qt, so we need to list the required deps here too, like qt5-default, libqt5webkit5(-dev?), etc
+# libwxgtk3: Trusty (14.04) uses 3.0-0, all other including Xenial (16.04) use 3.0-0v5
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libwxgtk3.0-0v5 (>= 3.0.0) | libwxgtk3.0-0 (>=3.0.0)")
 
 set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OPENSTUDIO_VERSION}/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,10 +136,6 @@ if(UNIX AND NOT APPLE)
   set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib")
 endif()
 
-# Build the OpenStudio Application
-# This option will require shared libs
-option(BUILD_OS_APP "Build OS App" ON)
-
 option(BUILD_PACKAGE "Build package" OFF)
 
 ###############################################################################
@@ -279,183 +275,6 @@ if(UNIX AND NOT APPLE)
 endif()
 
 ###############################################################################
-#                           D E P E N D E N C I E S                           #
-###############################################################################
-
-# Required dependencies
-
-# Threading library
-find_package(Threads)
-if(UNIX)
-  set(CMAKE_THREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}" CACHE STRING "Thread library used.")
-  mark_as_advanced(CMAKE_THREAD_LIBS)
-endif()
-
-if(BUILD_OS_APP)
-  # Qt
-  set(QT_INSTALL_DIR "" CACHE PATH "Path to Qt Install")
-  mark_as_advanced(QT_INSTALL_DIR)
-
-  if(NOT EXISTS ${QT_INSTALL_DIR})
-    # download qt
-    if(WIN32)
-      if(CMAKE_CL_64)
-        set(QT_ZIP_FILENAME "qt_5_11_msvc2017_64_shared.zip")
-        set(QT_ZIP_EXPECTED_MD5 "82f44a8decf101ca7cb7efafd899e8ee")
-      else()
-        set(QT_ZIP_FILENAME "DOES_NOT_EXIST_qt_5_11_msvc2017_32_shared.zip")
-        set(QT_ZIP_EXPECTED_MD5 "25abd383e7db2dfd971b4a4ef145002b")
-      endif()
-    elseif(APPLE)
-        set(QT_ZIP_FILENAME "DOES_NOT_EXIST_qt_5_11_osx_shared.tar.gz")
-        set(QT_ZIP_EXPECTED_MD5 "326887393d55b5da97a1be9764fb0d1b")
-    elseif(EXISTS "/etc/redhat-release")
-      set(QT_ZIP_FILENAME "DOES_NOT_EXIST_qt_5_11_redhat_shared.tar.gz")
-      set(QT_ZIP_EXPECTED_MD5 "b0610716854ed91a003347c455b22eb8")
-    else()
-      if(LSB_RELEASE_ID_SHORT MATCHES "18.04")
-        set(QT_ZIP_FILENAME "qt_5_11_linux_shared.tar.gz")
-        set(QT_ZIP_EXPECTED_MD5 "33c5a562935612625ec5e41fe4b75e17")
-      else()
-        # 16.04
-        set(QT_ZIP_FILENAME "qt_5_11_linux_shared_xenial.tar.gz")
-        set(QT_ZIP_EXPECTED_MD5 "cb02b8cb34de94038a1a7cba59c0c43a")
-      endif()
-    endif()
-
-    set(QT_ZIP_LOCAL_PATH "${PROJECT_BINARY_DIR}/${QT_ZIP_FILENAME}")
-    if(EXISTS "${QT_ZIP_LOCAL_PATH}")
-      file(MD5 "${QT_ZIP_LOCAL_PATH}" QT_ZIP_MD5)
-    endif()
-
-    if(NOT QT_ZIP_MD5 STREQUAL QT_ZIP_EXPECTED_MD5)
-      message(STATUS "Downloading Qt: ${QT_ZIP_FILENAME}")
-      file(DOWNLOAD "http://openstudio-resources.s3.amazonaws.com/dependencies/${QT_ZIP_FILENAME}"
-        ${QT_ZIP_LOCAL_PATH}
-        INACTIVITY_TIMEOUT 120
-        SHOW_PROGRESS
-        EXPECTED_MD5 ${QT_ZIP_EXPECTED_MD5})
-        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xfz ${QT_ZIP_LOCAL_PATH} WORKING_DIRECTORY "${PROJECT_BINARY_DIR}")
-    endif()
-  endif()
-
-  set(QT_INSTALL_DIR "${PROJECT_BINARY_DIR}/Qt-install/")
-
-  find_package(Qt5Core 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Widgets 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Sql 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Network 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Xml 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Concurrent 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5PrintSupport 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Gui 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Quick 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5QuickWidgets 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Qml 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5WebChannel 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5Positioning 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-
-  find_package(Qt5WebEngine 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  find_package(Qt5WebEngineWidgets 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  #find_package(Qt53DCore 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  #find_package(Qt53DInput 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-  #find_package(Qt53DRender 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-
-  if(APPLE)
-    set(QtWebEngineProcess "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app" CACHE PATH "Path to the QtWebEngineProcess")
-  else()
-    find_program(QtWebEngineProcess NAMES QtWebEngineProcess PATHS "${QT_INSTALL_DIR}/bin/" "${QT_INSTALL_DIR}/libexec/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Helpers" NO_DEFAULT_PATH)
-  endif()
-  find_file(icudtl NAMES icudtl.dat PATHS "${QT_INSTALL_DIR}/resources/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Resources" NO_DEFAULT_PATH)
-  find_file(qweb_resources NAMES qtwebengine_resources.pak PATHS "${QT_INSTALL_DIR}/resources/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Resources" NO_DEFAULT_PATH)
-  find_file(qweb_resources_100 NAMES qtwebengine_resources_100p.pak PATHS "${QT_INSTALL_DIR}/resources/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Resources" NO_DEFAULT_PATH)
-  find_file(qweb_resources_200 NAMES qtwebengine_resources_200p.pak PATHS "${QT_INSTALL_DIR}/resources/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Resources" NO_DEFAULT_PATH)
-
-  # DLM: why do we have QT_WEB_LIBS separate from QT_LIBS?  can we combine these?
-  # DLM: now the distincton should be between Qt libs linked by openstudio_modeleditor.so and the OS App
-  list(APPEND QT_WEB_LIBS Qt5::Core)
-  list(APPEND QT_WEB_LIBS Qt5::Gui)
-  list(APPEND QT_WEB_LIBS Qt5::WebEngine)
-  list(APPEND QT_WEB_LIBS Qt5::WebEngineCore)
-  list(APPEND QT_WEB_LIBS Qt5::WebEngineWidgets)
-  #list(APPEND QT_WEB_LIBS Qt5::3DCore)
-  #list(APPEND QT_WEB_LIBS Qt5::3DInput)
-  #list(APPEND QT_WEB_LIBS Qt5::3DRender)
-  set_target_properties(${QT_WEB_LIBS} PROPERTIES INTERFACE_LINK_LIBRARIES "")
-
-  if(NOT APPLE)
-
-    find_package(Qt5WebChannel 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-    list(APPEND QT_WEB_LIBS Qt5::WebChannel)
-
-    find_package(Qt5Quick 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-    list(APPEND QT_WEB_LIBS Qt5::Quick)
-
-    find_package(Qt5QuickWidgets 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-    list(APPEND QT_WEB_LIBS Qt5::QuickWidgets)
-
-    find_package(Qt5Qml 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-    list(APPEND QT_WEB_LIBS Qt5::Qml)
-
-    find_package(Qt5Positioning 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-    list(APPEND QT_WEB_LIBS Qt5::Positioning)
-
-    if(UNIX)
-      find_package(Qt5DBus 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-      list(APPEND QT_WEB_LIBS Qt5::DBus)
-
-      # there does not appear to be a normal qt finder for this
-      # DLM: actually there is, it is a plugin associated with Qt5::Gui
-      #message( Qt5Gui_PLUGINS = ${Qt5Gui_PLUGINS})
-      #get_target_property(Qt5QXcbIntegrationPlugin_LOCATION Qt5::QXcbIntegrationPlugin LOCATION)
-      #get_target_property(Qt5QXcbIntegrationPlugin_TYPE Qt5::QXcbIntegrationPlugin TYPE)
-      #message("Qt5::QXcbIntegrationPlugin Location = ${Qt5QXcbIntegrationPlugin_LOCATION}")
-      #message("Qt5::QXcbIntegrationPlugin Type = ${Qt5QXcbIntegrationPlugin_TYPE}")
-      list(APPEND QT_WEB_LIBS Qt5::QXcbIntegrationPlugin)
-      list(APPEND QT_WEB_LIBS Qt5::QXcbGlxIntegrationPlugin)
-    endif()
-  endif()
-
-  list(APPEND QT_LIBS Qt5::Core)
-  list(APPEND QT_LIBS Qt5::Widgets)
-  list(APPEND QT_LIBS Qt5::Network)
-  list(APPEND QT_LIBS Qt5::Xml)
-  list(APPEND QT_LIBS Qt5::Concurrent)
-  list(APPEND QT_LIBS Qt5::PrintSupport)
-  list(APPEND QT_LIBS Qt5::Gui)
-
-  if(WIN32)
-    find_package(Qt5WinExtras 5.11.2 REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
-    list(APPEND QT_LIBS Qt5::WinExtras)
-
-    find_library(QT_MAIN_LIB NAMES qtmain PATHS "${QT_INSTALL_DIR}/lib" NO_DEFAULT_PATH)
-    find_library(QT_MAIN_LIB_D NAMES qtmaind PATHS "${QT_INSTALL_DIR}/lib" NO_DEFAULT_PATH)
-  endif()
-
-  list(APPEND QT_INCLUDES ${Qt5Core_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES ${Qt5Concurrent_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES ${Qt5Widgets_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES ${Qt5Xml_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES ${Qt5Network_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES ${Qt5Gui_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES "${QT_INSTALL_DIR}/include/QtGui/5.11.2/QtGui") # needed by qtwinmigrate
-  list(APPEND QT_INCLUDES ${Qt5PrintSupport_INCLUDE_DIRS})
-
-  # DLM: added this, but seems to conflict with idea of a separate set of Qt Web dependencies?
-  list(APPEND QT_INCLUDES ${Qt5Network_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES ${Qt5WebEngine_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES ${Qt5WebEngineCore_INCLUDE_DIRS})
-  list(APPEND QT_INCLUDES ${Qt5WebEngineWidgets_INCLUDE_DIRS})
-
-  if(UNIX)
-    list(APPEND QT_INCLUDES ${Qt5XcbQpa_INCLUDE_DIRS})
-  endif()
-
-  set(CMAKE_AUTOMOC OFF)
-
-endif()
-
-###############################################################################
 #                    G I T    S U B M O D U L E    I N I T                    #
 ###############################################################################
 
@@ -469,6 +288,73 @@ if( NOT EXISTS "${PROJECT_SOURCE_DIR}/openstudio/.git" )
   execute_process(COMMAND git submodule update --init -- openstudio
                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
+endif()
+
+###############################################################################
+#                           D E P E N D E N C I E S                           #
+###############################################################################
+
+# Required dependencies
+
+# Threading library
+find_package(Threads)
+if(UNIX)
+  set(CMAKE_THREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}" CACHE STRING "Thread library used.")
+  mark_as_advanced(CMAKE_THREAD_LIBS)
+endif()
+
+
+# Qt via conan
+list(APPEND CONAN_OPTIONS "qt:commercial=False") # opensource
+list(APPEND CONAN_OPTIONS "qt:shared=True") # Shared, not static
+list(APPEND CONAN_OPTIONS "qt:GUI=True") # Support for GUI applications
+list(APPEND CONAN_OPTIONS "qt:widgets=True") # Support for GUI applications (Widgets are the base classes we use)
+
+list(APPEND CONAN_OPTIONS "qt:openssl=True") # For QNetwork
+list(APPEND CONAN_OPTIONS "qt:with_pcre2=True")
+list(APPEND CONAN_OPTIONS "qt:with_harfbuzz=True")
+
+# Database stuff, we don't use QSql at all actuallly
+list(APPEND CONAN_OPTIONS "qt:with_sqlite3=False") # sqlite
+list(APPEND CONAN_OPTIONS "qt:with_mysql=False")  # MySQL
+list(APPEND CONAN_OPTIONS "qt:with_pq=False")     # PostgreSQL
+list(APPEND CONAN_OPTIONS "qt:with_odbc=False")   # Oracle Database
+
+# I think that's why produces Qt Positioning
+list(APPEND CONAN_OPTIONS "qt:qtlocation=True")
+
+# Stuff we definitely want to enable because it's disabled, and we are actively using find_package to find them below
+list(APPEND CONAN_OPTIONS "qt:qtwebengine=True")
+list(APPEND CONAN_OPTIONS "qt:qtwebview=True")
+list(APPEND CONAN_OPTIONS "qt:qtwebchannel=True")
+
+list(APPEND CONAN_OPTIONS "qt:qttools=False")
+
+list(APPEND CONAN_OPTIONS "qt:qtmultimedia=False")
+# Already turned off by qtmultimedia=False
+list(APPEND CONAN_OPTIONS "qt:with_sdl2=False")
+list(APPEND CONAN_OPTIONS "qt:with_openal=False")
+
+list(APPEND CONAN_OPTIONS "qt:qtdoc=False")
+list(APPEND CONAN_OPTIONS "qt:qtsensors=False")
+list(APPEND CONAN_OPTIONS "qt:qtconnectivity=False")
+list(APPEND CONAN_OPTIONS "qt:qtwayland=False")
+list(APPEND CONAN_OPTIONS "qt:qtpurchasing=False")
+
+# TODO: Temporary option
+option(WITH_ICU BOOL ON)
+
+# Convenient place to bump version
+set(QT_VERSION "5.12.3")
+
+if (WITH_ICU)
+  # This recipe is the same as bincrafters', except I enabled ICU with ICU 64.2
+  set(CONAN_QT "qt/${QT_VERSION}@jmarrec/testing")
+  # Recipe has 2.3.0 which appears on the bincrafter repo but cannot be found...
+  #set(CONAN_HARFBUZZ "harfbuzz/2.4.0@bincrafters/stable")
+  list(APPEND CONAN_OPTIONS "qt:with_icu=True")
+else()
+  set(CONAN_QT "qt/${QT_VERSION}@bincrafters/testing")
 endif()
 
 
@@ -513,21 +399,148 @@ add_subdirectory(openstudio)
 message("RUBY_INCLUDE_DIRS = ${RUBY_INCLUDE_DIRS}")
 
 ###############################################################################
+#                                     Q T                                     #
+###############################################################################
+
+# Now that openstudio (core) has run conan, we need to pick up the Qt dependencies
+
+# Qt
+
+# TODO: replace with more appropriate find_package in CONFIG Mode
+# eg: find_package(Qt5Core 5.12.3 CONFIG REQUIRED)
+
+set(QT_INSTALL_DIR "${CONAN_QT_ROOT}")
+
+
+
+find_package(Qt5Core ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Widgets ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Sql ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Network ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Xml ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Concurrent ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5PrintSupport ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Gui ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Quick ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5QuickWidgets ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Qml ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5WebChannel ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5Positioning ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+
+find_package(Qt5WebEngine ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+find_package(Qt5WebEngineWidgets ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+#find_package(Qt53DCore ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+#find_package(Qt53DInput ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+#find_package(Qt53DRender ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+
+if(APPLE)
+  set(QtWebEngineProcess "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Helpers/QtWebEngineProcess.app" CACHE PATH "Path to the QtWebEngineProcess")
+else()
+  find_program(QtWebEngineProcess NAMES QtWebEngineProcess PATHS "${QT_INSTALL_DIR}/bin/" "${QT_INSTALL_DIR}/libexec/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Helpers" NO_DEFAULT_PATH)
+endif()
+find_file(icudtl NAMES icudtl.dat PATHS "${QT_INSTALL_DIR}/resources/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Resources" NO_DEFAULT_PATH)
+find_file(qweb_resources NAMES qtwebengine_resources.pak PATHS "${QT_INSTALL_DIR}/resources/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Resources" NO_DEFAULT_PATH)
+find_file(qweb_resources_100 NAMES qtwebengine_resources_100p.pak PATHS "${QT_INSTALL_DIR}/resources/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Resources" NO_DEFAULT_PATH)
+find_file(qweb_resources_200 NAMES qtwebengine_resources_200p.pak PATHS "${QT_INSTALL_DIR}/resources/" "${QT_INSTALL_DIR}/lib/QtWebEngineCore.framework/Resources" NO_DEFAULT_PATH)
+
+# DLM: why do we have QT_WEB_LIBS separate from QT_LIBS?  can we combine these?
+# DLM: now the distincton should be between Qt libs linked by openstudio_modeleditor.so and the OS App
+list(APPEND QT_WEB_LIBS Qt5::Core)
+list(APPEND QT_WEB_LIBS Qt5::Gui)
+list(APPEND QT_WEB_LIBS Qt5::WebEngine)
+list(APPEND QT_WEB_LIBS Qt5::WebEngineCore)
+list(APPEND QT_WEB_LIBS Qt5::WebEngineWidgets)
+#list(APPEND QT_WEB_LIBS Qt5::3DCore)
+#list(APPEND QT_WEB_LIBS Qt5::3DInput)
+#list(APPEND QT_WEB_LIBS Qt5::3DRender)
+set_target_properties(${QT_WEB_LIBS} PROPERTIES INTERFACE_LINK_LIBRARIES "")
+
+if(NOT APPLE)
+
+  find_package(Qt5WebChannel ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+  list(APPEND QT_WEB_LIBS Qt5::WebChannel)
+
+  find_package(Qt5Quick ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+  list(APPEND QT_WEB_LIBS Qt5::Quick)
+
+  find_package(Qt5QuickWidgets ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+  list(APPEND QT_WEB_LIBS Qt5::QuickWidgets)
+
+  find_package(Qt5Qml ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+  list(APPEND QT_WEB_LIBS Qt5::Qml)
+
+  find_package(Qt5Positioning ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+  list(APPEND QT_WEB_LIBS Qt5::Positioning)
+
+  if(UNIX)
+    find_package(Qt5DBus ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+    list(APPEND QT_WEB_LIBS Qt5::DBus)
+
+    # there does not appear to be a normal qt finder for this
+    # DLM: actually there is, it is a plugin associated with Qt5::Gui
+    #message( Qt5Gui_PLUGINS = ${Qt5Gui_PLUGINS})
+    #get_target_property(Qt5QXcbIntegrationPlugin_LOCATION Qt5::QXcbIntegrationPlugin LOCATION)
+    #get_target_property(Qt5QXcbIntegrationPlugin_TYPE Qt5::QXcbIntegrationPlugin TYPE)
+    #message("Qt5::QXcbIntegrationPlugin Location = ${Qt5QXcbIntegrationPlugin_LOCATION}")
+    #message("Qt5::QXcbIntegrationPlugin Type = ${Qt5QXcbIntegrationPlugin_TYPE}")
+    list(APPEND QT_WEB_LIBS Qt5::QXcbIntegrationPlugin)
+    list(APPEND QT_WEB_LIBS Qt5::QXcbGlxIntegrationPlugin)
+  endif()
+endif()
+
+list(APPEND QT_LIBS Qt5::Core)
+list(APPEND QT_LIBS Qt5::Widgets)
+list(APPEND QT_LIBS Qt5::Network)
+list(APPEND QT_LIBS Qt5::Xml)
+list(APPEND QT_LIBS Qt5::Concurrent)
+list(APPEND QT_LIBS Qt5::PrintSupport)
+list(APPEND QT_LIBS Qt5::Gui)
+
+if(WIN32)
+  find_package(Qt5WinExtras ${QT_VERSION} REQUIRED PATHS ${QT_INSTALL_DIR} NO_DEFAULT_PATH)
+  list(APPEND QT_LIBS Qt5::WinExtras)
+
+  find_library(QT_MAIN_LIB NAMES qtmain PATHS "${QT_INSTALL_DIR}/lib" NO_DEFAULT_PATH)
+  find_library(QT_MAIN_LIB_D NAMES qtmaind PATHS "${QT_INSTALL_DIR}/lib" NO_DEFAULT_PATH)
+endif()
+
+list(APPEND QT_INCLUDES ${Qt5Core_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES ${Qt5Concurrent_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES ${Qt5Widgets_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES ${Qt5Xml_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES ${Qt5Network_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES ${Qt5Gui_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES "${QT_INSTALL_DIR}/include/QtGui/${QT_VERSION}/QtGui") # needed by qtwinmigrate
+list(APPEND QT_INCLUDES ${Qt5PrintSupport_INCLUDE_DIRS})
+
+# DLM: added this, but seems to conflict with idea of a separate set of Qt Web dependencies?
+list(APPEND QT_INCLUDES ${Qt5Network_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES ${Qt5WebEngine_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES ${Qt5WebEngineCore_INCLUDE_DIRS})
+list(APPEND QT_INCLUDES ${Qt5WebEngineWidgets_INCLUDE_DIRS})
+
+if(UNIX)
+  list(APPEND QT_INCLUDES ${Qt5XcbQpa_INCLUDE_DIRS})
+endif()
+
+set(CMAKE_AUTOMOC OFF)
+
+
+
+###############################################################################
 #                                T A R G E T S                                #
 ###############################################################################
 
 set(project_directories "")
-if(BUILD_OS_APP)
-  if(WIN32)
-    include_directories("${PROJECT_SOURCE_DIR}/src/qtwinmigrate")
-    list(APPEND project_directories "qtwinmigrate")
-  endif()
-  list(APPEND project_directories "utilities")
-  list(APPEND project_directories "model_editor")
-  list(APPEND project_directories "bimserver")
-  list(APPEND project_directories "openstudio_lib")
-  list(APPEND project_directories "openstudio_app")
+if(WIN32)
+  include_directories("${PROJECT_SOURCE_DIR}/src/qtwinmigrate")
+  list(APPEND project_directories "qtwinmigrate")
 endif()
+list(APPEND project_directories "utilities")
+list(APPEND project_directories "model_editor")
+list(APPEND project_directories "bimserver")
+list(APPEND project_directories "openstudio_lib")
+list(APPEND project_directories "openstudio_app")
 
 foreach(D ${project_directories})
   add_subdirectory(src/${D})
@@ -540,20 +553,15 @@ endforeach()
 # Export targets and generate OpenStudioCoreConfig.cmake
 
 set(all_lib_targets "")
-if(BUILD_OS_APP)
-  if(WIN32)
-    list(APPEND all_lib_targets "qtwinmigrate")
-  endif()
-  list(APPEND all_lib_targets "openstudio_modeleditor")
-  list(APPEND all_lib_targets "openstudio_bimserver")
-  list(APPEND all_lib_targets "openstudio_lib")
+if(WIN32)
+  list(APPEND all_lib_targets "qtwinmigrate")
 endif()
+list(APPEND all_lib_targets "openstudio_modeleditor")
+list(APPEND all_lib_targets "openstudio_bimserver")
+list(APPEND all_lib_targets "openstudio_lib")
 
 set(all_exe_targets "")
-
-if(BUILD_OS_APP)
-  list(APPEND all_exe_targets "OpenStudioApp")
-endif()
+list(APPEND all_exe_targets "OpenStudioApp")
 
 if(UNIX AND NOT APPLE)
   foreach(targ ${all_lib_targets} ${all_exe_targets} ${ALL_TESTING_TARGETS})
@@ -575,42 +583,40 @@ endif()
 # CPack: TODO
 
 
-if(BUILD_OS_APP)
-  set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OPENSTUDIO_VERSION}/)
+set(CPACK_INSTALL_PREFIX /usr/local/openstudio-${OPENSTUDIO_VERSION}/)
 
-  # Same for OpenStudioApp
-  execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/OpenStudioApp ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp)
-  execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/OpenStudioApp ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp-${OPENSTUDIO_VERSION})
+# Same for OpenStudioApp
+execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/OpenStudioApp ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp)
+execute_process(COMMAND ln -sf ${CPACK_INSTALL_PREFIX}bin/OpenStudioApp ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp-${OPENSTUDIO_VERSION})
 
-  # Have this link be installed with the .deb package in /usr/local/bin
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp DESTINATION /usr/local/bin COMPONENT CLI)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp-${OPENSTUDIO_VERSION} DESTINATION /usr/local/bin COMPONENT CLI)
+# Have this link be installed with the .deb package in /usr/local/bin
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp DESTINATION /usr/local/bin COMPONENT CLI)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp-${OPENSTUDIO_VERSION} DESTINATION /usr/local/bin COMPONENT CLI)
 
 
-  # Create a proper App with file associations
+# Create a proper App with file associations
 
-  # Install the .desktop manifest (allows the App to be seen in the Dash and adding to the dock, and to map it a mimetype)
-  install(FILES "${PROJECT_SOURCE_DIR}/openstudioapp.desktop" DESTINATION /usr/share/applications)
-  # Install the XML mime info
-  install(FILES "${PROJECT_SOURCE_DIR}/x-openstudio.xml" DESTINATION /usr/share/mime/application)
+# Install the .desktop manifest (allows the App to be seen in the Dash and adding to the dock, and to map it a mimetype)
+install(FILES "${PROJECT_SOURCE_DIR}/openstudioapp.desktop" DESTINATION /usr/share/applications)
+# Install the XML mime info
+install(FILES "${PROJECT_SOURCE_DIR}/x-openstudio.xml" DESTINATION /usr/share/mime/application)
 
-  cpack_add_component(Resources
-    DISPLAY_NAME "Application Resources"
-    DESCRIPTION "Resource Files used by the OpenStudio Application"
-  )
+cpack_add_component(Resources
+  DISPLAY_NAME "Application Resources"
+  DESCRIPTION "Resource Files used by the OpenStudio Application"
+)
 
-  cpack_add_component(OpenStudioApp
-    DISPLAY_NAME "OpenStudio Application"
-    DESCRIPTION "OpenStudio Application"
-  )
+cpack_add_component(OpenStudioApp
+  DISPLAY_NAME "OpenStudio Application"
+  DESCRIPTION "OpenStudio Application"
+)
 
-  cpack_ifw_configure_component(Resources
-    REQUIRES_ADMIN_RIGHTS
-  )
+cpack_ifw_configure_component(Resources
+  REQUIRES_ADMIN_RIGHTS
+)
 
-  cpack_ifw_configure_component(OpenStudioApp
-    DEPENDS Resources CLI
-    SCRIPT src/openstudio_app/install_operations.qs
-    REQUIRES_ADMIN_RIGHTS
-  )
-endif()
+cpack_ifw_configure_component(OpenStudioApp
+  DEPENDS Resources CLI
+  SCRIPT src/openstudio_app/install_operations.qs
+  REQUIRES_ADMIN_RIGHTS
+)

--- a/ProjectMacros.cmake
+++ b/ProjectMacros.cmake
@@ -194,8 +194,8 @@ macro(CREATE_TEST_TARGETS BASE_NAME SRC DEPENDENCIES)
     endif()
 
     target_link_libraries(${BASE_NAME}_tests
-      CONAN_PKG::gtest
       ${ALL_DEPENDENCIES}
+      CONAN_PKG::gtest
     )
 
     ADD_GOOGLE_TESTS(${BASE_NAME}_tests ${SRC})

--- a/README.md
+++ b/README.md
@@ -24,9 +24,14 @@ More information and documentation is available at the [OpenStudio](https://www.
 
 ## Developer Information
 
-[OpenStudio](https://github.com/NREL/OpenStudio) (core SDK) is included as a `git submodule` in the folder `./openstudio`. Be sure to initialize submodules, which can be done during cloning by passing the `--recurse-submodules` flag, or after the fact via `cd OpenStudioApplication/openstudio && git submodule init && git submodule update`.  When pulling updates from the remote repository run `git pull --recurse-submodules` and then `git submodule update --remote --recursive`.
+[OpenStudio](https://github.com/NREL/OpenStudio) (core SDK) is included as a `git submodule` in the folder `./openstudio`.
 
-**Temporary information:** Current this submodule is tracking branch `https://github.com/NREL/OpenStudio/tree/OS_App_killswitch` which will soon replace `NREL/OpenStudio/develop3`.
+* **Be sure to initialize submodules**, which can be done during cloning by passing the `--recurse-submodules` flag, or after the fact via `cd OpenStudioApplication/openstudio && git submodule init && git submodule update`.
+* When pulling updates from the remote repository run `git pull --recurse-submodules` and then `git submodule update --remote --merge --recursive`: this will update all submodules to track the latest from remote (if `.gitmodules` is correctly set)
+
+**Temporary information:**
+* Currently different branches could be tracking several different submodule branches, be sure to check `.gitmodules`.
+* Generally speaking, this submodule is tracking branch `https://github.com/NREL/OpenStudio/tree/OS_App_killswitch` (or a modified version of it) which will soon replace `NREL/OpenStudio/develop3`.
 
 To build, use the root of the repo when configuring with ccmake.
 

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -19,6 +19,7 @@ set(${target_name}_test_src
 )
 
 set(${target_name}_depends
+  Threads::Threads
   CONAN_PKG::boost_filesystem
   CONAN_PKG::boost_regex
   CONAN_PKG::boost_log


### PR DESCRIPTION
Fix #11

I merged all active branches: `OS_app_killswitch`, `OS_App_killswitch_packaging `and `Move_ruby_modeleditor`.

Then I enabled conan-qt. It builds on my Ubuntu 16.04 machine, but I expect there will be problems.

Packaging still needs some deep attention, there are a lot of things that are still in openstudio (core) that shouldn't. Allow will need to figure out how to have this work on fresh machines for Qt deps.

**Note: I made the git submodule track my jmarrec:OpenStudio/OS_App_killswitch_Qt for now**