### PR TITLE
 Disallow picking Zones with useIdealAirLoads in the plenum picker in OS App to avoid crash in E+

### DIFF
--- a/src/openstudio_lib/InspectorView.cpp
+++ b/src/openstudio_lib/InspectorView.cpp
@@ -919,7 +919,9 @@ NewPlenumDialog::NewPlenumDialog(QWidget * parent)
       it != allZones.end();
       ++it)
   {
-    if( (! it->isPlenum()) && it->equipment().empty() && (! it->airLoopHVAC()) )
+    // equipment() is empty if you useIdealAirLoads, so we have to filter that out explicitly
+    // to match AirLoopHVACSupplyReturnPlenum_Impl::setThermalZone and AirLoopHVACReturnPlenum_Impl::setThermalZone
+    if( (! it->isPlenum()) && it->equipment().empty() && (! it->airLoopHVAC()) && (! it->useIdealAirLoads()) )
     {
       zoneChooser->addItem(QString::fromStdString(it->name().get()),toQString(it->handle()));
     }


### PR DESCRIPTION
Fix https://github.com/NREL/OpenStudio/issues/3083

Same change as https://github.com/NREL/OpenStudio/pull/3772 for develop3/OpenStudioApplication