### PR TITLE
Fix #3743 - Implement a reportItemsLater for ConstructionObjectVectorController

### DIFF
--- a/src/openstudio_lib/ConstructionInspectorView.cpp
+++ b/src/openstudio_lib/ConstructionInspectorView.cpp
@@ -196,6 +196,7 @@ void ConstructionInspectorView::detach()
 {
   m_standardsInformationWidget->detach();
   m_constructionVC->detach();
+  m_constructionVC->reportItems();
   m_construction = boost::none;
 }
 

--- a/src/openstudio_lib/ConstructionObjectVectorController.hpp
+++ b/src/openstudio_lib/ConstructionObjectVectorController.hpp
@@ -32,6 +32,8 @@
 
 #include "ModelObjectVectorController.hpp"
 
+class QMutex;
+
 namespace openstudio {
 
 class ConstructionObjectVectorController : public ModelObjectVectorController
@@ -42,15 +44,25 @@ public:
 
   ConstructionObjectVectorController(QWidget * parentWidget);
 
-  virtual ~ConstructionObjectVectorController() {}
+  // Need to delete the QMutex
+  virtual ~ConstructionObjectVectorController();
 
   void setParentWidget(QWidget * parentWidget);
+
+public slots:
+
+  // reportItemsLater should be used as it wraps the call to reportItems in a QTimer::singleShot
+  // which eventually calls ModelObjectVector::reportItems
+  void reportItemsLater();
+  void reportItems();
 
 protected:
 
   virtual void onChangeRelationship(const model::ModelObject& modelObject, int index, Handle newHandle, Handle oldHandle) override;
 
   virtual void onDataChange(const model::ModelObject& modelObject) override;
+
+  virtual void onChange(const model::ModelObject& modelObject) override;
 
   virtual std::vector<OSItemId> makeVector() override;
 
@@ -61,6 +73,9 @@ protected:
   virtual void onDrop(const OSItemId& itemId) override;
 
 private:
+
+  bool m_reportScheduled;
+  QMutex * m_reportItemsMutex;
 
   enum LayerType
   {


### PR DESCRIPTION
Fix NREL/OpenStudio#3743

Initially I tried to call `reportItems()` at the end of `ConstructionObjectVectorController::onDrop` after [ConstructionObjectVectorController.cpp#L141](https://github.com/NREL/OpenStudioApplication/blob/develop/src/openstudio_lib/ConstructionObjectVectorController.cpp#L141)

This works, but throws a message
```
[openstudio.model.LayeredConstruction] <0> Skipping layer 2 in Object of type 'OS:Construction' and named 'Construction 1', as there is no Material object referenced by the corresponding field.
```
when saving the model, it works fine though. But still, not a good message to see in the console.


So I resolved to using a `QMutex` and call it in a `QTimer::singleShot`,  adapted from [SystemAvailabilityVectorController](https://github.com/NREL/OpenStudioApplication/blob/develop/src/openstudio_lib/HVACSystemsController.cpp#L1874:L1895)

I connected the signals `onDataChange`, `onChangeRelationship` and `onChange` to this `reporItemsLater()` slot.

Behavior in OS App appears ok now, when I drag a material it is updated directly.