### PR TITLE
Hide Fan Schedule for Fan:ConstantVolume and Fan:VariableVolume **only** on an AirLoopHVAC

### DIFF
--- a/src/model_editor/AccessPolicyStore.cpp
+++ b/src/model_editor/AccessPolicyStore.cpp
@@ -281,6 +281,42 @@ namespace openstudio
       return FREE;
     }
 
+    bool AccessPolicy::setAccess(unsigned int index, AccessPolicy::ACCESS_LEVEL accessLevel)
+    {
+      if (m_numNormalFields == std::numeric_limits<unsigned>::max()){
+        OS_ASSERT(false);
+      }
+      if (m_extensibleSize == std::numeric_limits<unsigned>::max()){
+        OS_ASSERT(false);
+      }
+
+      if(index<m_numNormalFields)
+      {
+        auto i = m_accessMap.find(index);
+        if( i != m_accessMap.end() )
+        {
+          (*i).second = accessLevel;
+          return true;
+        } else {
+          m_accessMap[index] = accessLevel;
+        }
+      }
+      else
+      {
+        index-=m_numNormalFields;
+        index = index % m_extensibleSize;
+        auto i = m_extensibleAccessMap.find(index);
+        if( i != m_extensibleAccessMap.end() )
+        {
+          (*i).second = accessLevel;
+          return true;
+        } else {
+          m_extensibleAccessMap[index] = accessLevel;
+        }
+      }
+      return false;
+    }
+
 
     AccessPolicyStore::AccessPolicyStore()
     {

--- a/src/model_editor/AccessPolicyStore.hpp
+++ b/src/model_editor/AccessPolicyStore.hpp
@@ -42,6 +42,8 @@
 
 namespace openstudio
 {
+  class InspectorView;
+
   namespace model
   {
 
@@ -60,6 +62,7 @@ namespace openstudio
     class MODELEDITOR_API AccessPolicy
     {
       friend class AccessParser;
+      friend class openstudio::InspectorView; // For overriding via setAccess
 
     public:
 
@@ -81,6 +84,10 @@ namespace openstudio
         * for that bogus index though. :) )
         */
       ACCESS_LEVEL getAccess(unsigned int index) const;
+
+    protected:
+      // For specific overriding of access policies, such as hiding Fan Schedule only on AirLoopHVAC for eg
+      bool setAccess(unsigned int index, ACCESS_LEVEL);
 
     private:
       std::map<unsigned int, ACCESS_LEVEL> m_accessMap;
@@ -107,7 +114,7 @@ namespace openstudio
       bool loadFile( const openstudio::path& path );
       bool loadFile( const std::vector<char> &data );
 
-      /*!Each IddObjectType has a uniqueAcessPolicy. This function will retrieve it*/
+      /*!Each IddObjectType has a uniqueAccessPolicy. This function will retrieve it*/
       const AccessPolicy* getPolicy( const openstudio::IddObjectType& )const;
 
       /* clear the map*/


### PR DESCRIPTION
Fix https://github.com/NREL/OpenStudio/issues/3627

Hide Fan Schedule for Fan:ConstantVolume and Fan:VariableVolume **only** on an AirLoopHVAC, by conditionally changing the AccessPolicy for that field.