### PR TITLE
Build and install the openstudio_modeleditor.so module. Modifying PAT…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -606,6 +606,11 @@ foreach(D ${project_directories})
   add_subdirectory(src/${D})
 endforeach()
 
+if( WIN32 )
+  set(RUBY_MINGW_STUB_LIB "${PROJECT_BINARY_DIR}/openstudio/Ruby-mingw-install/libx64-msvcrt-ruby250.dll.a")
+endif()
+
+add_subdirectory("ruby")
 
 ###############################################################################
 #                        E X P O R T    T A R G E T S                         #

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -7,17 +7,19 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --unresolved-symbols=ignore-all")
 endif()
 
+if (UNIX)
+  # Disable register warnings
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=register -Wno-register")
+endif()
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR} )
-
-#target_link_libraries(init_openstudio
- ##ruby_OpenStudioModelEditor # linked by openstudio_modeleditor.so only, for SketchUp plugin
-#)
 
 add_library(openstudio_modeleditor_rb MODULE
   RubyAPI.hpp
   openstudio_modeleditor_rb.cpp
 )
+target_include_directories(openstudio_modeleditor_rb PRIVATE ${RUBY_INCLUDE_DIRS})
+
 set_target_properties(openstudio_modeleditor_rb PROPERTIES PREFIX "")
 set_target_properties(openstudio_modeleditor_rb PROPERTIES OUTPUT_NAME openstudio_modeleditor)
 
@@ -32,6 +34,7 @@ else()
 endif()
 
 if(MSVC)
+  # wd4996=no deprecated warnings ; wd5033=register
   set_target_properties(openstudio_modeleditor_rb PROPERTIES COMPILE_FLAGS "/bigobj /wd4996 /wd5033")
 endif()
 
@@ -42,13 +45,10 @@ add_custom_command(TARGET openstudio_modeleditor_rb
 
 target_link_libraries(openstudio_modeleditor_rb
   ruby_OpenStudioModelEditor
-  openstudio_modeleditor
-  ${QT_LIBS}
+  openstudio_lib
+  openstudio_bimserver
+  ${QT_WEB_LIBS}
 )
-
-if( UNIX AND NOT APPLE )
-  target_link_libraries(openstudio_modeleditor_rb ${QT_WEB_LIBS})
-endif()
 
 if( WIN32 )
   target_link_libraries(openstudio_modeleditor_rb ${RUBY_MINGW_STUB_LIB})
@@ -57,21 +57,6 @@ endif()
 install(TARGETS openstudio_modeleditor_rb DESTINATION Ruby COMPONENT "RubyAPI")
 install(FILES openstudio_modeleditor.rb DESTINATION Ruby COMPONENT "RubyAPI")
 
-
-# don't need modeleditor libs in pat
 if( BUILD_PAT )
-  if( APPLE )
-    install(TARGETS openstudio_rb
-      DESTINATION ParametricAnalysisTool.app/Contents/Resources/OpenStudio/Ruby/
-      COMPONENT PAT
-    )
-    install(FILES openstudio.rb
-      DESTINATION ParametricAnalysisTool.app/Contents/Resources/OpenStudio/Ruby/
-      COMPONENT PAT
-    )
-    install(DIRECTORY openstudio
-      DESTINATION ParametricAnalysisTool.app/Contents/Resources/OpenStudio/Ruby/
-      COMPONENT PAT
-    )
-  endif()
+  # don't need modeleditor libs in pat
 endif()

--- a/ruby/RubyAPI.hpp
+++ b/ruby/RubyAPI.hpp
@@ -1,0 +1,45 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2008-2019, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#ifndef RUBYAPI_HPP
+#define RUBYAPI_HPP
+
+  #if (_WIN32 || _MSC_VER)
+    #ifdef openstudio_rb_EXPORTS 
+      #define RUBY_API __declspec(dllexport)
+    #elif defined openstudio_modeleditor_rb_EXPORTS
+      #define RUBY_API __declspec(dllexport)
+    #else
+      #define RUBY_API __declspec(dllimport)
+    #endif
+  #else
+    #define RUBY_API
+  #endif
+
+#endif

--- a/ruby/openstudio_modeleditor.rb
+++ b/ruby/openstudio_modeleditor.rb
@@ -29,37 +29,53 @@
 
 # add binary dir to system path
 original_path = ENV['PATH']
+original_dll_directory = nil
 platform_specific_path = nil
+
 if /mswin/.match(RUBY_PLATFORM) or /mingw/.match(RUBY_PLATFORM)
-  front = []
-  back = []
-  original_path.split(';').each do |p|
-    if /SketchUp/.match(p)
-      if /platform_specific/.match(p)
-        platform_specific_path = p
-      end
-      front << p
-    else
-      back << p
-    end
+  
+  require 'fiddle/import'
+  require 'fiddle/types'
+  module WinAPI
+    extend Fiddle::Importer
+    dlload 'kernel32.dll'
+    include Fiddle::Win32Types
+    extern 'BOOL SetDllDirectory(LPCSTR)'
+    extern 'DWORD GetDllDirectory(DWORD, LPSTR)'
   end
 
-  ENV['PATH'] = "#{front.join(';')};#{File.dirname(__FILE__)};#{back.join(';')}"
+  buffer = 1024
+  original_dll_directory = Fiddle::Pointer.malloc(buffer) 
+  WinAPI.GetDllDirectory(buffer, original_dll_directory)
+  
+  qt_dll_path = File.expand_path(File.join(File.dirname(__FILE__), '../bin/'))
+  WinAPI.SetDllDirectory(qt_dll_path)
 
 else
 
   # Do something here for Mac OSX environments
-  ENV['PATH'] = "#{File.dirname(__FILE__)}:#{original_path}"
+  qt_so_path = File.expand_path(File.join(File.dirname(__FILE__), '../bin/'))
+  ENV['PATH'] = "#{qt_so_path}:#{original_path}"
 end
 
-# require openstudio
-require_relative 'openstudio'
+begin
 
-# require openstudio_modeleditor.so
-require_relative 'openstudio_modeleditor.so'
+  # require openstudio
+  require_relative 'openstudio'
 
-# restore original path
-ENV['PATH'] = original_path
+  # require openstudio_modeleditor.so
+  require_relative 'openstudio_modeleditor.so'
+  
+  # add this directory to Ruby load path
+  $:.unshift(File.expand_path(File.dirname(__FILE__)))
+  
+ensure
 
-# add this directory to Ruby load path
-$:.unshift(File.expand_path(File.dirname(__FILE__)))
+  # restore original path
+  ENV['PATH'] = original_path
+  
+  if original_dll_directory
+    WinAPI.SetDllDirectory(original_dll_directory)
+  end
+  
+end

--- a/src/model_editor/Application.cpp
+++ b/src/model_editor/Application.cpp
@@ -83,10 +83,17 @@ QCoreApplication* ApplicationSingleton::application(bool gui)
       QCoreApplication::setAttribute(Qt::AA_MacPluginApplication, true);
 
       // dir containing the current module, can be openstudio.so or openstudio.exe
-      openstudio::path openstudioDirPath = getOpenStudioModuleDirectory();
+      openstudio::path openstudioModuleDirPath = getOpenStudioModuleDirectory();
 
       // Add the current module path to the backup plugin search location
-      QCoreApplication::addLibraryPath(toQString(openstudioDirPath));
+      QCoreApplication::addLibraryPath(toQString(openstudioModuleDirPath));
+
+      // DLM: the code below is pretty kludgy, it depends on installation of the OpenStudio Application components
+      openstudio::path openstudioPossibleBinDirPath = openstudioModuleDirPath / openstudio::toPath("../bin/");
+      QCoreApplication::addLibraryPath(toQString(openstudioPossibleBinDirPath));
+      
+      openstudioPossibleBinDirPath = openstudioModuleDirPath / openstudio::toPath("../bin/platforms/");
+      QCoreApplication::addLibraryPath(toQString(openstudioPossibleBinDirPath));
 
       // Make the ruby path the default plugin search location
 //#if defined(Q_OS_DARWIN)


### PR DESCRIPTION
…H in the load scripts does not seem to be sufficient to load the Qt dlls in Ruby 2.5.0, using new approach based on fiddle.  I have not tested this on Mac at all.