### PR TITLE
Fix #2613 - Disable switching tabs while measures are syncing with library

### DIFF
--- a/src/openstudio_lib/ScriptsTabView.cpp
+++ b/src/openstudio_lib/ScriptsTabView.cpp
@@ -107,6 +107,7 @@ void ScriptsTabView::openUpdateMeasuresDlg()
 
   openstudio::OSAppBase * app = OSAppBase::instance();
 
+  // Disable all Vertical Tab Buttons (so you can't click on another tab while it's doing its thing)
   app->currentDocument()->disable();
 
   WorkflowJSON workflow = app->currentDocument()->model().workflowJSON();
@@ -115,12 +116,14 @@ void ScriptsTabView::openUpdateMeasuresDlg()
   m_syncMeasuresDialog->setGeometry(app->currentDocument()->mainWindow()->geometry());
   m_syncMeasuresDialog->exec();
 
-  app->currentDocument()->enable();
-
   app->editController()->reset();
   workflowView->refreshAllViews();
 
   m_updateMeasuresButton->setEnabled(true);
+
+  // Re-enable the ability to switch tabs
+  app->currentDocument()->enable();
+
 }
 
 } // openstudio


### PR DESCRIPTION
Fix https://github.com/NREL/OpenStudio/issues/2613

Move the re-enabling of Vertical Tab Buttons at the end of the syncing

Confirmed it fixes it on Ubuntu. Will need testers on other machines to test this with the CI-produced installers. @DavidGoldwasser @kbenne FYI