### PR TITLE
Improve reporting when IDF isn't valid as Draft Stricness after "Import IDF"

### DIFF
--- a/src/openstudio_app/OpenStudioApp.cpp
+++ b/src/openstudio_app/OpenStudioApp.cpp
@@ -593,42 +593,83 @@ void OpenStudioApp::importIdf()
 
         connectOSDocumentSignals();
 
-        QMessageBox messageBox; // (parent); ETH: ... but is hidden, so don't actually use
-        messageBox.setText("Some portions of the idf file were not imported.");
-        messageBox.setInformativeText("Only geometry, constructions, loads, thermal zones, and schedules are supported by the OpenStudio IDF import feature.");
-
         QString log;
 
-        for( const auto & message : trans.errors() ) {
-          log.append("\n");
-          log.append("\n");
-          log.append(QString::fromStdString(message.logMessage()));
-          log.append("\n");
-          log.append("\n");
-        }
+        // DetailedText of QMessageBox is always interpreted a raw text, so not HTML formatting.
+/*
+ *        if (!trans.errors().empty()) {
+ *          log.append("<h3>Errors:</h3>");
+ *          log.append("<ul>");
+ *          for( const auto & message : trans.errors() ) {
+ *            log.append("<li>" + QString::fromStdString(message.logMessage()) + "</li>");
+ *          }
+ *          log.append("</ul>");
+ *        }
+ *
+ *        if (!trans.warnings().empty()) {
+ *          log.append("<h3>Warnings:</h3>");
+ *          log.append("<ul>");
+ *          for( const auto & message : trans.warnings() ) {
+ *            log.append("<li>" + QString::fromStdString(message.logMessage()) + "</li>");
+ *          }
+ *          log.append("</ul>");
+ *        }
+ *
+ *        if (!trans.untranslatedIdfObjects().empty()) {
+ *          log.append("<h3>The following idf objects were not imported:</h3>");
+ *          log.append("<ul>");
+ *
+ *          for( const auto & idfObject : trans.untranslatedIdfObjects() ) {
+ *            std::string message;
+ *            if( auto name = idfObject.name() ) {
+ *              message = idfObject.iddObject().name() + " named " + name.get();
+ *            } else {
+ *              message = "Unnamed " + idfObject.iddObject().name();
+ *            }
+ *            log.append("<li>" + QString::fromStdString(message) + "</li>");
+ *          }
+ *          log.append("</ul>");
+ *        }
+ */
 
-        for( const auto & message : trans.warnings() ) {
-          log.append(QString::fromStdString(message.logMessage()));
-          log.append("\n");
-          log.append("\n");
-        }
-
-        log.append("The following idf objects were not imported.");
-        log.append("\n");
-        log.append("\n");
-
-        for( const auto & idfObject : trans.untranslatedIdfObjects() ) {
-          std::string message;
-          if( auto name = idfObject.name() ) {
-            message = idfObject.iddObject().name() + " named " + name.get();
-          } else {
-            message = "Unammed " + idfObject.iddObject().name();
+        if (!trans.errors().empty()) {
+          log.append("=============== Errors ===============\n\n");
+          for( const auto & message : trans.errors() ) {
+            log.append(" * " + QString::fromStdString(message.logMessage()) + "\n");
           }
-          log.append(QString::fromStdString(message));
-          log.append("\n");
-          log.append("\n");
+          log.append("\n\n");
         }
 
+        if (!trans.warnings().empty()) {
+          log.append("============== Warnings ==============\n\n");
+          for( const auto & message : trans.warnings() ) {
+            log.append(" * " + QString::fromStdString(message.logMessage()) + "\n");
+          }
+          log.append("\n\n");
+        }
+
+        if (!trans.untranslatedIdfObjects().empty()) {
+          log.append("==== The following idf objects were not imported ====\n\n");
+
+          for( const auto & idfObject : trans.untranslatedIdfObjects() ) {
+            std::string message;
+            if( auto name = idfObject.name() ) {
+              message = idfObject.iddObject().name() + " named " + name.get();
+            } else {
+              message = "Unnamed " + idfObject.iddObject().name();
+            }
+            log.append(" * " + QString::fromStdString(message) + "\n");
+          }
+        }
+
+        QString text("<strong>Some portions of the IDF file were not imported.</strong>");
+
+        // QMessageBox messageBox; // (parent); ETH: ... but is hidden, so don't actually use
+        // messageBox.setText(text);
+
+        // Passing parent = nullptr on purpose here
+        QMessageBox messageBox(QMessageBox::Warning, "IDF Import", text, QMessageBox::NoButton, nullptr, Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
+        messageBox.setInformativeText("Only geometry, constructions, loads, thermal zones, and schedules are supported by the OpenStudio IDF import feature.");
         messageBox.setDetailedText(log);
 
         messageBox.exec();


### PR DESCRIPTION
## Improve reporting when IDF isn't valid at Draft strictness

Fixes https://github.com/NREL/OpenStudio/issues/228

### IDF File has no version object:

![image](https://user-images.githubusercontent.com/5479063/70141148-af4a2980-1696-11ea-8202-d12fb794eca4.png)

###  IDF File is older:

![image](https://user-images.githubusercontent.com/5479063/70141376-37c8ca00-1697-11ea-95a6-de405ea69cb6.png)


###  IDF File is too new:

![image](https://user-images.githubusercontent.com/5479063/70141354-2c759e80-1697-11ea-9b24-35c9a5e2fd14.png)


###  IDF File has same version but it still failed:

![image](https://user-images.githubusercontent.com/5479063/70141306-17007480-1697-11ea-9811-913d97f9ecd8.png)


## Additional changes
Improve reporting when portions of IDF weren't imported:

![image](https://user-images.githubusercontent.com/5479063/70141122-9b9ec300-1696-11ea-8925-431e10bc188e.png)
