### PR TITLE
 Add Comfort Fields for People Definition on the Loads definition tab

### DIFF
--- a/src/openstudio_lib/PeopleInspectorView.cpp
+++ b/src/openstudio_lib/PeopleInspectorView.cpp
@@ -172,6 +172,7 @@ PeopleDefinitionInspectorView::PeopleDefinitionInspectorView(bool isIP,
   QFrame * line = new QFrame();
   line->setFrameShape(QFrame::HLine);
   line->setFrameShadow(QFrame::Sunken);
+  // Important not to specific AlignTop & AlignLeft  or it's not displayed
   m_mainGridLayout->addWidget(line, row, 0, 1, 3); // , Qt::AlignTop|Qt::AlignLeft);
 
   // Confort stuff

--- a/src/openstudio_lib/PeopleInspectorView.hpp
+++ b/src/openstudio_lib/PeopleInspectorView.hpp
@@ -86,6 +86,8 @@ class PeopleDefinitionInspectorView : public ModelObjectInspectorView
 
     void refresh();
 
+    // Adjusts the stretch of rows after adding/removing extensible groups, so that all rows have a stretch factor or 0 (default)
+    // except the row following the last row with data that has a strech of 1 => pushes everything up
     void adjustRowStretch();
 
     OSComboBox2 * addThermalComfortModelTypeComboBox(int groupIndex);
@@ -110,7 +112,9 @@ class PeopleDefinitionInspectorView : public ModelObjectInspectorView
     std::vector<OSComboBox2*> m_thermalComfortModelTypeComboBoxes;
     QPushButton * addBtn;
     QPushButton * removeBtn;
-    QHBoxLayout * lastHBoxLayout; // For deletion
+
+    // For deletion / indexing (really only the vectors could be used)
+    QHBoxLayout * lastHBoxLayout;
     QWidget* lastRowWidget;
     std::vector<QHBoxLayout*> m_HBoxLayouts;
     std::vector<QWidget*> m_rowWidgets;


### PR DESCRIPTION
Fix https://github.com/NREL/OpenStudio/issues/2756

This was a bit tricky since there was no prior: none of the other loads have extensible fields. I'm not 100% everything is super clean on Qt side, hence why I assigned you @kbenne .

I have put the extensible "row" of gridlayout in a widget (I put the QHBoxLayout in a QWidget, then add the QWidget to the QGridLayout) so I could hide it then remove it, it wasn't working if I put the QHBoxLayout directly insie the QGridLayout

Here's a GIF demo of the UI/UX. As you can see, the add / remove works. The add button is disabled once you reach the maximum number of extensible fields (5 in this objects). The remove button is disabled if there are no groups to remove.

![2756_Comfort](https://user-images.githubusercontent.com/5479063/70280959-fa109200-17b9-11ea-8a16-fd6e50b38202.gif)
