### PR TITLE
Fix crash in Schedule tab

### DIFF
--- a/src/openstudio_lib/ScheduleDayView.cpp
+++ b/src/openstudio_lib/ScheduleDayView.cpp
@@ -2034,7 +2034,7 @@ void DayScheduleScene::refresh()
       boost::optional<Unit> _toUnits = _scheduleTypeLimits->units(isIP);
 
       if (isIP && (_siUnits.get() != _toUnits.get())) {
-        OSQuantityVector quantities;
+        OSQuantityVector quantities(_toUnits.get());
         for (const auto& value: m_scheduleDay.values()) {
           // Do conversion:
           Quantity q = openstudio::Quantity(value, _siUnits.get());


### PR DESCRIPTION
Fix #57.

This happens because of a change I introduced in https://github.com/NREL/OpenStudioApplication/commit/d35baa747314d83a23f17235875d41b05900c496 when we started develop3 and removed Quantities from the model API. `ScheduleDay::getValues(bool isIP)` was removed from the API as a result, so the conversion had to be moved to OpenStudioApplication.

This line is the problem:

https://github.com/NREL/OpenStudioApplication/blob/04c47eab982efc2384492322acee29292b278cd5/src/openstudio_lib/ScheduleDayView.cpp#L2037

The `OSQuantityVector` should be initialized with `_toUnits.get()` so that the push_back doesn't LOG_AND_THROW an error for non matching units

