### PR TITLE
 Move PathWatcher / WorkspaceWatcher tests to OpenStudioApplication

### DIFF
--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -136,6 +136,7 @@ jobs:
 
         if [ "$RUNNER_OS" == "Linux" ]; then
           echo "Install needed system dependencies for OPENGL (due to Qt) for Linux"
+          sudo apt update
           sudo apt install -y mesa-common-dev libglu1-mesa-dev patchelf
         elif [ "$RUNNER_OS" == "Windows" ]; then
           curl -L -O https://download.qt.io/official_releases/qt-installer-framework/3.2.2/QtInstallerFramework-win-x86.exe

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -358,7 +358,7 @@ jobs:
       run: |
           Xvfb :99 &
           export DISPLAY=:99
-          ctest -j -T test --no-compress-output -c $BUILD_TYPE || true
+          ctest -j -T test --no-compress-output -C $BUILD_TYPE || true
 
     - name: Archive test results?
       uses: actions/upload-artifact@v2

--- a/CMake/FindPackageHandleStandardArgs.cmake
+++ b/CMake/FindPackageHandleStandardArgs.cmake
@@ -1,0 +1,466 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindPackageHandleStandardArgs
+-----------------------------
+
+This module provides a function intended to be used in :ref:`Find Modules`
+implementing :command:`find_package(<PackageName>)` calls.  It handles the
+``REQUIRED``, ``QUIET`` and version-related arguments of ``find_package``.
+It also sets the ``<PackageName>_FOUND`` variable.  The package is
+considered found if all variables listed contain valid results, e.g.
+valid filepaths.
+
+.. command:: find_package_handle_standard_args
+
+  There are two signatures::
+
+    find_package_handle_standard_args(<PackageName>
+      (DEFAULT_MSG|<custom-failure-message>)
+      <required-var>...
+      )
+
+    find_package_handle_standard_args(<PackageName>
+      [FOUND_VAR <result-var>]
+      [REQUIRED_VARS <required-var>...]
+      [VERSION_VAR <version-var>]
+      [HANDLE_COMPONENTS]
+      [CONFIG_MODE]
+      [NAME_MISMATCHED]
+      [REASON_FAILURE_MESSAGE <reason-failure-message>]
+      [FAIL_MESSAGE <custom-failure-message>]
+      )
+
+  The ``<PackageName>_FOUND`` variable will be set to ``TRUE`` if all
+  the variables ``<required-var>...`` are valid and any optional
+  constraints are satisfied, and ``FALSE`` otherwise.  A success or
+  failure message may be displayed based on the results and on
+  whether the ``REQUIRED`` and/or ``QUIET`` option was given to
+  the :command:`find_package` call.
+
+  The options are:
+
+  ``(DEFAULT_MSG|<custom-failure-message>)``
+    In the simple signature this specifies the failure message.
+    Use ``DEFAULT_MSG`` to ask for a default message to be computed
+    (recommended).  Not valid in the full signature.
+
+  ``FOUND_VAR <result-var>``
+    Obsolete.  Specifies either ``<PackageName>_FOUND`` or
+    ``<PACKAGENAME>_FOUND`` as the result variable.  This exists only
+    for compatibility with older versions of CMake and is now ignored.
+    Result variables of both names are always set for compatibility.
+
+  ``REQUIRED_VARS <required-var>...``
+    Specify the variables which are required for this package.
+    These may be named in the generated failure message asking the
+    user to set the missing variable values.  Therefore these should
+    typically be cache entries such as ``FOO_LIBRARY`` and not output
+    variables like ``FOO_LIBRARIES``. This option is mandatory if
+    ``HANDLE_COMPONENTS`` is not specified.
+
+  ``VERSION_VAR <version-var>``
+    Specify the name of a variable that holds the version of the package
+    that has been found.  This version will be checked against the
+    (potentially) specified required version given to the
+    :command:`find_package` call, including its ``EXACT`` option.
+    The default messages include information about the required
+    version and the version which has been actually found, both
+    if the version is ok or not.
+
+  ``HANDLE_COMPONENTS``
+    Enable handling of package components.  In this case, the command
+    will report which components have been found and which are missing,
+    and the ``<PackageName>_FOUND`` variable will be set to ``FALSE``
+    if any of the required components (i.e. not the ones listed after
+    the ``OPTIONAL_COMPONENTS`` option of :command:`find_package`) are
+    missing.
+
+  ``CONFIG_MODE``
+    Specify that the calling find module is a wrapper around a
+    call to ``find_package(<PackageName> NO_MODULE)``.  This implies
+    a ``VERSION_VAR`` value of ``<PackageName>_VERSION``.  The command
+    will automatically check whether the package configuration file
+    was found.
+
+  ``REASON_FAILURE_MESSAGE <reason-failure-message>``
+    Specify a custom message of the reason for the failure which will be
+    appended to the default generated message.
+
+  ``FAIL_MESSAGE <custom-failure-message>``
+    Specify a custom failure message instead of using the default
+    generated message.  Not recommended.
+
+  ``NAME_MISMATCHED``
+    Indicate that the ``<PackageName>`` does not match
+    ``${CMAKE_FIND_PACKAGE_NAME}``. This is usually a mistake and raises a
+    warning, but it may be intentional for usage of the command for components
+    of a larger package.
+
+Example for the simple signature:
+
+.. code-block:: cmake
+
+  find_package_handle_standard_args(LibXml2 DEFAULT_MSG
+    LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR)
+
+The ``LibXml2`` package is considered to be found if both
+``LIBXML2_LIBRARY`` and ``LIBXML2_INCLUDE_DIR`` are valid.
+Then also ``LibXml2_FOUND`` is set to ``TRUE``.  If it is not found
+and ``REQUIRED`` was used, it fails with a
+:command:`message(FATAL_ERROR)`, independent whether ``QUIET`` was
+used or not.  If it is found, success will be reported, including
+the content of the first ``<required-var>``.  On repeated CMake runs,
+the same message will not be printed again.
+
+.. note::
+
+  If ``<PackageName>`` does not match ``CMAKE_FIND_PACKAGE_NAME`` for the
+  calling module, a warning that there is a mismatch is given. The
+  ``FPHSA_NAME_MISMATCHED`` variable may be set to bypass the warning if using
+  the old signature and the ``NAME_MISMATCHED`` argument using the new
+  signature. To avoid forcing the caller to require newer versions of CMake for
+  usage, the variable's value will be used if defined when the
+  ``NAME_MISMATCHED`` argument is not passed for the new signature (but using
+  both is an error)..
+
+Example for the full signature:
+
+.. code-block:: cmake
+
+  find_package_handle_standard_args(LibArchive
+    REQUIRED_VARS LibArchive_LIBRARY LibArchive_INCLUDE_DIR
+    VERSION_VAR LibArchive_VERSION)
+
+In this case, the ``LibArchive`` package is considered to be found if
+both ``LibArchive_LIBRARY`` and ``LibArchive_INCLUDE_DIR`` are valid.
+Also the version of ``LibArchive`` will be checked by using the version
+contained in ``LibArchive_VERSION``.  Since no ``FAIL_MESSAGE`` is given,
+the default messages will be printed.
+
+Another example for the full signature:
+
+.. code-block:: cmake
+
+  find_package(Automoc4 QUIET NO_MODULE HINTS /opt/automoc4)
+  find_package_handle_standard_args(Automoc4  CONFIG_MODE)
+
+In this case, a ``FindAutmoc4.cmake`` module wraps a call to
+``find_package(Automoc4 NO_MODULE)`` and adds an additional search
+directory for ``automoc4``.  Then the call to
+``find_package_handle_standard_args`` produces a proper success/failure
+message.
+#]=======================================================================]
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageMessage.cmake)
+
+# internal helper macro
+macro(_FPHSA_FAILURE_MESSAGE _msg)
+  set (__msg "${_msg}")
+  if (FPHSA_REASON_FAILURE_MESSAGE)
+    string(APPEND __msg "\n    Reason given by package: ${FPHSA_REASON_FAILURE_MESSAGE}\n")
+  endif()
+  if (${_NAME}_FIND_REQUIRED)
+    message(FATAL_ERROR "${__msg}")
+  else ()
+    if (NOT ${_NAME}_FIND_QUIETLY)
+      message(STATUS "${__msg}")
+    endif ()
+  endif ()
+endmacro()
+
+
+# internal helper macro to generate the failure message when used in CONFIG_MODE:
+macro(_FPHSA_HANDLE_FAILURE_CONFIG_MODE)
+  # <PackageName>_CONFIG is set, but FOUND is false, this means that some other of the REQUIRED_VARS was not found:
+  if(${_NAME}_CONFIG)
+    _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: missing:${MISSING_VARS} (found ${${_NAME}_CONFIG} ${VERSION_MSG})")
+  else()
+    # If _CONSIDERED_CONFIGS is set, the config-file has been found, but no suitable version.
+    # List them all in the error message:
+    if(${_NAME}_CONSIDERED_CONFIGS)
+      set(configsText "")
+      list(LENGTH ${_NAME}_CONSIDERED_CONFIGS configsCount)
+      math(EXPR configsCount "${configsCount} - 1")
+      foreach(currentConfigIndex RANGE ${configsCount})
+        list(GET ${_NAME}_CONSIDERED_CONFIGS ${currentConfigIndex} filename)
+        list(GET ${_NAME}_CONSIDERED_VERSIONS ${currentConfigIndex} version)
+        string(APPEND configsText "\n    ${filename} (version ${version})")
+      endforeach()
+      if (${_NAME}_NOT_FOUND_MESSAGE)
+        if (FPHSA_REASON_FAILURE_MESSAGE)
+          string(PREPEND FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}\n    ")
+        else()
+          set(FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}")
+        endif()
+      else()
+        string(APPEND configsText "\n")
+      endif()
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} ${VERSION_MSG}, checked the following files:${configsText}")
+
+    else()
+      # Simple case: No Config-file was found at all:
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: found neither ${_NAME}Config.cmake nor ${_NAME_LOWER}-config.cmake ${VERSION_MSG}")
+    endif()
+  endif()
+endmacro()
+
+
+function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
+
+  # Set up the arguments for `cmake_parse_arguments`.
+  set(options  CONFIG_MODE  HANDLE_COMPONENTS NAME_MISMATCHED)
+  set(oneValueArgs  FAIL_MESSAGE  REASON_FAILURE_MESSAGE VERSION_VAR  FOUND_VAR)
+  set(multiValueArgs REQUIRED_VARS)
+
+  # Check whether we are in 'simple' or 'extended' mode:
+  set(_KEYWORDS_FOR_EXTENDED_MODE  ${options} ${oneValueArgs} ${multiValueArgs} )
+  list(FIND _KEYWORDS_FOR_EXTENDED_MODE "${_FIRST_ARG}" INDEX)
+
+  unset(FPHSA_NAME_MISMATCHED_override)
+  if (DEFINED FPHSA_NAME_MISMATCHED)
+    # If the variable NAME_MISMATCHED variable is set, error if it is passed as
+    # an argument. The former is for old signatures, the latter is for new
+    # signatures.
+    list(FIND ARGN "NAME_MISMATCHED" name_mismatched_idx)
+    if (NOT name_mismatched_idx EQUAL "-1")
+      message(FATAL_ERROR
+        "The `NAME_MISMATCHED` argument may only be specified by the argument or "
+        "the variable, not both.")
+    endif ()
+
+    # But use the variable if it is not an argument to avoid forcing minimum
+    # CMake version bumps for calling modules.
+    set(FPHSA_NAME_MISMATCHED_override "${FPHSA_NAME_MISMATCHED}")
+  endif ()
+
+  if(${INDEX} EQUAL -1)
+    set(FPHSA_FAIL_MESSAGE ${_FIRST_ARG})
+    set(FPHSA_REQUIRED_VARS ${ARGN})
+    set(FPHSA_VERSION_VAR)
+  else()
+    cmake_parse_arguments(FPHSA "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${_FIRST_ARG} ${ARGN})
+
+    if(FPHSA_UNPARSED_ARGUMENTS)
+      message(FATAL_ERROR "Unknown keywords given to FIND_PACKAGE_HANDLE_STANDARD_ARGS(): \"${FPHSA_UNPARSED_ARGUMENTS}\"")
+    endif()
+
+    if(NOT FPHSA_FAIL_MESSAGE)
+      set(FPHSA_FAIL_MESSAGE  "DEFAULT_MSG")
+    endif()
+
+    # In config-mode, we rely on the variable <PackageName>_CONFIG, which is set by find_package()
+    # when it successfully found the config-file, including version checking:
+    if(FPHSA_CONFIG_MODE)
+      list(INSERT FPHSA_REQUIRED_VARS 0 ${_NAME}_CONFIG)
+      list(REMOVE_DUPLICATES FPHSA_REQUIRED_VARS)
+      set(FPHSA_VERSION_VAR ${_NAME}_VERSION)
+    endif()
+
+    if(NOT FPHSA_REQUIRED_VARS AND NOT FPHSA_HANDLE_COMPONENTS)
+      message(FATAL_ERROR "No REQUIRED_VARS specified for FIND_PACKAGE_HANDLE_STANDARD_ARGS()")
+    endif()
+  endif()
+
+  if (DEFINED FPHSA_NAME_MISMATCHED_override)
+    set(FPHSA_NAME_MISMATCHED "${FPHSA_NAME_MISMATCHED_override}")
+  endif ()
+
+  if (DEFINED CMAKE_FIND_PACKAGE_NAME
+      AND NOT FPHSA_NAME_MISMATCHED
+      AND NOT _NAME STREQUAL CMAKE_FIND_PACKAGE_NAME)
+    message(AUTHOR_WARNING
+      "The package name passed to `find_package_handle_standard_args` "
+      "(${_NAME}) does not match the name of the calling package "
+      "(${CMAKE_FIND_PACKAGE_NAME}). This can lead to problems in calling "
+      "code that expects `find_package` result variables (e.g., `_FOUND`) "
+      "to follow a certain pattern.")
+  endif ()
+
+# now that we collected all arguments, process them
+
+  if("x${FPHSA_FAIL_MESSAGE}" STREQUAL "xDEFAULT_MSG")
+    set(FPHSA_FAIL_MESSAGE "Could NOT find ${_NAME}")
+  endif()
+
+  if (FPHSA_REQUIRED_VARS)
+    list(GET FPHSA_REQUIRED_VARS 0 _FIRST_REQUIRED_VAR)
+  endif()
+
+  string(TOUPPER ${_NAME} _NAME_UPPER)
+  string(TOLOWER ${_NAME} _NAME_LOWER)
+
+  if(FPHSA_FOUND_VAR)
+    set(_FOUND_VAR_UPPER ${_NAME_UPPER}_FOUND)
+    set(_FOUND_VAR_MIXED ${_NAME}_FOUND)
+    if(FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_MIXED  OR  FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_UPPER)
+      set(_FOUND_VAR ${FPHSA_FOUND_VAR})
+    else()
+      message(FATAL_ERROR "The argument for FOUND_VAR is \"${FPHSA_FOUND_VAR}\", but only \"${_FOUND_VAR_MIXED}\" and \"${_FOUND_VAR_UPPER}\" are valid names.")
+    endif()
+  else()
+    set(_FOUND_VAR ${_NAME_UPPER}_FOUND)
+  endif()
+
+  # collect all variables which were not found, so they can be printed, so the
+  # user knows better what went wrong (#6375)
+  set(MISSING_VARS "")
+  set(DETAILS "")
+  # check if all passed variables are valid
+  set(FPHSA_FOUND_${_NAME} TRUE)
+  foreach(_CURRENT_VAR ${FPHSA_REQUIRED_VARS})
+    if(NOT ${_CURRENT_VAR})
+      set(FPHSA_FOUND_${_NAME} FALSE)
+      string(APPEND MISSING_VARS " ${_CURRENT_VAR}")
+    else()
+      string(APPEND DETAILS "[${${_CURRENT_VAR}}]")
+    endif()
+  endforeach()
+  if(FPHSA_FOUND_${_NAME})
+    set(${_NAME}_FOUND TRUE)
+    set(${_NAME_UPPER}_FOUND TRUE)
+  else()
+    set(${_NAME}_FOUND FALSE)
+    set(${_NAME_UPPER}_FOUND FALSE)
+  endif()
+
+  # component handling
+  unset(FOUND_COMPONENTS_MSG)
+  unset(MISSING_COMPONENTS_MSG)
+
+  if(FPHSA_HANDLE_COMPONENTS)
+    foreach(comp ${${_NAME}_FIND_COMPONENTS})
+      if(${_NAME}_${comp}_FOUND)
+
+        if(NOT DEFINED FOUND_COMPONENTS_MSG)
+          set(FOUND_COMPONENTS_MSG "found components:")
+        endif()
+        string(APPEND FOUND_COMPONENTS_MSG " ${comp}")
+
+      else()
+
+        if(NOT DEFINED MISSING_COMPONENTS_MSG)
+          set(MISSING_COMPONENTS_MSG "missing components:")
+        endif()
+        string(APPEND MISSING_COMPONENTS_MSG " ${comp}")
+
+        if(${_NAME}_FIND_REQUIRED_${comp})
+          set(${_NAME}_FOUND FALSE)
+          string(APPEND MISSING_VARS " ${comp}")
+        endif()
+
+      endif()
+    endforeach()
+    set(COMPONENT_MSG "${FOUND_COMPONENTS_MSG} ${MISSING_COMPONENTS_MSG}")
+    string(APPEND DETAILS "[c${COMPONENT_MSG}]")
+  endif()
+
+  # version handling:
+  set(VERSION_MSG "")
+  set(VERSION_OK TRUE)
+
+  # check with DEFINED here as the requested or found version may be "0"
+  if (DEFINED ${_NAME}_FIND_VERSION)
+    if(DEFINED ${FPHSA_VERSION_VAR})
+      set(_FOUND_VERSION ${${FPHSA_VERSION_VAR}})
+
+      if(${_NAME}_FIND_VERSION_EXACT)       # exact version required
+        # count the dots in the version string
+        string(REGEX REPLACE "[^.]" "" _VERSION_DOTS "${_FOUND_VERSION}")
+        # add one dot because there is one dot more than there are components
+        string(LENGTH "${_VERSION_DOTS}." _VERSION_DOTS)
+        if (_VERSION_DOTS GREATER ${_NAME}_FIND_VERSION_COUNT)
+          # Because of the C++ implementation of find_package() ${_NAME}_FIND_VERSION_COUNT
+          # is at most 4 here. Therefore a simple lookup table is used.
+          if (${_NAME}_FIND_VERSION_COUNT EQUAL 1)
+            set(_VERSION_REGEX "[^.]*")
+          elseif (${_NAME}_FIND_VERSION_COUNT EQUAL 2)
+            set(_VERSION_REGEX "[^.]*\\.[^.]*")
+          elseif (${_NAME}_FIND_VERSION_COUNT EQUAL 3)
+            set(_VERSION_REGEX "[^.]*\\.[^.]*\\.[^.]*")
+          else ()
+            set(_VERSION_REGEX "[^.]*\\.[^.]*\\.[^.]*\\.[^.]*")
+          endif ()
+          string(REGEX REPLACE "^(${_VERSION_REGEX})\\..*" "\\1" _VERSION_HEAD "${_FOUND_VERSION}")
+          unset(_VERSION_REGEX)
+          if (NOT ${_NAME}_FIND_VERSION VERSION_EQUAL _VERSION_HEAD)
+            set(VERSION_MSG "Found unsuitable version \"${_FOUND_VERSION}\", but required is exact version \"${${_NAME}_FIND_VERSION}\"")
+            set(VERSION_OK FALSE)
+          else ()
+            set(VERSION_MSG "(found suitable exact version \"${_FOUND_VERSION}\")")
+          endif ()
+          unset(_VERSION_HEAD)
+        else ()
+          if (NOT ${_NAME}_FIND_VERSION VERSION_EQUAL _FOUND_VERSION)
+            set(VERSION_MSG "Found unsuitable version \"${_FOUND_VERSION}\", but required is exact version \"${${_NAME}_FIND_VERSION}\"")
+            set(VERSION_OK FALSE)
+          else ()
+            set(VERSION_MSG "(found suitable exact version \"${_FOUND_VERSION}\")")
+          endif ()
+        endif ()
+        unset(_VERSION_DOTS)
+
+      else()     # minimum version specified:
+        if (${_NAME}_FIND_VERSION VERSION_GREATER _FOUND_VERSION)
+          set(VERSION_MSG "Found unsuitable version \"${_FOUND_VERSION}\", but required is at least \"${${_NAME}_FIND_VERSION}\"")
+          set(VERSION_OK FALSE)
+        else ()
+          set(VERSION_MSG "(found suitable version \"${_FOUND_VERSION}\", minimum required is \"${${_NAME}_FIND_VERSION}\")")
+        endif ()
+      endif()
+
+    else()
+
+      # if the package was not found, but a version was given, add that to the output:
+      if(${_NAME}_FIND_VERSION_EXACT)
+         set(VERSION_MSG "(Required is exact version \"${${_NAME}_FIND_VERSION}\")")
+      else()
+         set(VERSION_MSG "(Required is at least version \"${${_NAME}_FIND_VERSION}\")")
+      endif()
+
+    endif()
+  else ()
+    # Check with DEFINED as the found version may be 0.
+    if(DEFINED ${FPHSA_VERSION_VAR})
+      set(VERSION_MSG "(found version \"${${FPHSA_VERSION_VAR}}\")")
+    endif()
+  endif ()
+
+  if(VERSION_OK)
+    string(APPEND DETAILS "[v${${FPHSA_VERSION_VAR}}(${${_NAME}_FIND_VERSION})]")
+  else()
+    set(${_NAME}_FOUND FALSE)
+  endif()
+
+
+  # print the result:
+  if (${_NAME}_FOUND)
+    FIND_PACKAGE_MESSAGE(${_NAME} "Found ${_NAME}: ${${_FIRST_REQUIRED_VAR}} ${VERSION_MSG} ${COMPONENT_MSG}" "${DETAILS}")
+  else ()
+
+    if(FPHSA_CONFIG_MODE)
+      _FPHSA_HANDLE_FAILURE_CONFIG_MODE()
+    else()
+      if(NOT VERSION_OK)
+        set(RESULT_MSG)
+        if (_FIRST_REQUIRED_VAR)
+          string (APPEND RESULT_MSG "found ${${_FIRST_REQUIRED_VAR}}")
+        endif()
+        if (COMPONENT_MSG)
+          if (RESULT_MSG)
+            string (APPEND RESULT_MSG ", ")
+          endif()
+          string (APPEND RESULT_MSG "${FOUND_COMPONENTS_MSG}")
+        endif()
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: ${VERSION_MSG} (${RESULT_MSG})")
+      else()
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} (missing:${MISSING_VARS}) ${VERSION_MSG}")
+      endif()
+    endif()
+
+  endif ()
+
+  set(${_NAME}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)
+  set(${_NAME_UPPER}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)
+endfunction()

--- a/CMake/FindPackageMessage.cmake
+++ b/CMake/FindPackageMessage.cmake
@@ -1,0 +1,48 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindPackageMessage
+------------------
+
+.. code-block:: cmake
+
+  find_package_message(<name> "message for user" "find result details")
+
+This function is intended to be used in FindXXX.cmake modules files.
+It will print a message once for each unique find result.  This is
+useful for telling the user where a package was found.  The first
+argument specifies the name (XXX) of the package.  The second argument
+specifies the message to display.  The third argument lists details
+about the find result so that if they change the message will be
+displayed again.  The macro also obeys the QUIET argument to the
+find_package command.
+
+Example:
+
+.. code-block:: cmake
+
+  if(X11_FOUND)
+    find_package_message(X11 "Found X11: ${X11_X11_LIB}"
+      "[${X11_X11_LIB}][${X11_INCLUDE_DIR}]")
+  else()
+   ...
+  endif()
+#]=======================================================================]
+
+function(find_package_message pkg msg details)
+  # Avoid printing a message repeatedly for the same find result.
+  if(NOT ${pkg}_FIND_QUIETLY)
+    string(REPLACE "\n" "" details "${details}")
+    set(DETAILS_VAR FIND_PACKAGE_MESSAGE_DETAILS_${pkg})
+    if(NOT "${details}" STREQUAL "${${DETAILS_VAR}}")
+      # The message has not yet been printed.
+      message(STATUS "${msg}")
+
+      # Save the find details in the cache to avoid printing the same
+      # message again.
+      set("${DETAILS_VAR}" "${details}"
+        CACHE INTERNAL "Details about finding ${pkg}")
+    endif()
+  endif()
+endfunction()

--- a/CMake/FindRuby.cmake
+++ b/CMake/FindRuby.cmake
@@ -1,0 +1,522 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindRuby
+--------
+
+Find Ruby
+
+This module finds if Ruby is installed and determines where the
+include files and libraries are.  Ruby 1.8 through 2.7 are
+supported.
+
+The minimum required version of Ruby can be specified using the
+standard syntax, e.g.
+
+.. code-block:: cmake
+
+  find_package(Ruby 2.5.1 EXACT REQUIRED)
+  # OR
+  find_package(Ruby 2.4)
+
+It also determines what the name of the library is.
+
+Virtual environments such as RVM are handled as well, by passing
+the argument ``Ruby_FIND_VIRTUALENV``
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module will set the following variables in your project:
+
+``Ruby_FOUND``
+  set to true if ruby was found successfully
+``Ruby_EXECUTABLE``
+  full path to the ruby binary
+``Ruby_INCLUDE_DIRS``
+  include dirs to be used when using the ruby library
+``Ruby_LIBRARIES``
+  libraries needed to use ruby from C.
+``Ruby_VERSION``
+  the version of ruby which was found, e.g. "1.8.7"
+``Ruby_VERSION_MAJOR``
+  Ruby major version.
+``Ruby_VERSION_MINOR``
+  Ruby minor version.
+``Ruby_VERSION_PATCH``
+  Ruby patch version.
+
+
+The following variables are also provided for compatibility reasons,
+don't use them in new code:
+
+``RUBY_EXECUTABLE``
+  same as Ruby_EXECUTABLE.
+``RUBY_INCLUDE_DIRS``
+  same as Ruby_INCLUDE_DIRS.
+``RUBY_INCLUDE_PATH``
+  same as Ruby_INCLUDE_DIRS.
+``RUBY_LIBRARY``
+  same as Ruby_LIBRARY.
+``RUBY_VERSION``
+  same as Ruby_VERSION.
+``RUBY_FOUND``
+  same as Ruby_FOUND.
+
+Hints
+^^^^^
+
+``Ruby_ROOT_DIR``
+  Define the root directory of a Ruby installation.
+
+``Ruby_FIND_VIRTUALENV``
+  This variable defines the handling of virtual environments managed by
+  ``rvm``. It is meaningful only when a virtual environment
+  is active (i.e. the ``rvm`` script has been evaluated or at least the
+  ``MY_RUBY_HOME`` environment variable is set).
+  The ``Ruby_FIND_VIRTUALENV`` variable can be set to empty or
+  one of the following:
+
+  * ``FIRST``: The virtual environment is used before any other standard
+    paths to look-up for the interpreter. This is the default.
+  * ``ONLY``: Only the virtual environment is used to look-up for the
+    interpreter.
+  * ``STANDARD``: The virtual environment is not used to look-up for the
+    interpreter (assuming it isn't still in the PATH...)
+
+#]=======================================================================]
+
+# Backwards compatibility
+# Define camel case versions of input variables
+foreach(UPPER
+    RUBY_EXECUTABLE
+    RUBY_LIBRARY
+    RUBY_INCLUDE_DIR
+    RUBY_CONFIG_INCLUDE_DIR
+    )
+    if (DEFINED ${UPPER})
+      string(REPLACE "RUBY_" "Ruby_" Camel ${UPPER})
+        if (NOT DEFINED ${Camel})
+            set(${Camel} ${${UPPER}})
+        endif()
+    endif()
+endforeach()
+
+#   Ruby_ARCHDIR=`$RUBY -r rbconfig -e 'printf("%s",Config::CONFIG@<:@"archdir"@:>@)'`
+#   Ruby_SITEARCHDIR=`$RUBY -r rbconfig -e 'printf("%s",Config::CONFIG@<:@"sitearchdir"@:>@)'`
+#   Ruby_SITEDIR=`$RUBY -r rbconfig -e 'printf("%s",Config::CONFIG@<:@"sitelibdir"@:>@)'`
+#   Ruby_LIBDIR=`$RUBY -r rbconfig -e 'printf("%s",Config::CONFIG@<:@"libdir"@:>@)'`
+#   Ruby_LIBRUBYARG=`$RUBY -r rbconfig -e 'printf("%s",Config::CONFIG@<:@"LIBRUBYARG_SHARED"@:>@)'`
+
+# uncomment the following line to get debug output for this file
+# set(_Ruby_DEBUG_OUTPUT TRUE)
+
+# Determine the list of possible names of the ruby executable depending
+# on which version of ruby is required
+set(_Ruby_POSSIBLE_EXECUTABLE_NAMES ruby)
+
+# If not specified, allow everything as far back as 1.8.0
+if(NOT DEFINED Ruby_FIND_VERSION_MAJOR)
+  set(Ruby_FIND_VERSION "1.8.0")
+  set(Ruby_FIND_VERSION_MAJOR 1)
+  set(Ruby_FIND_VERSION_MINOR 8)
+  set(Ruby_FIND_VERSION_PATCH 0)
+endif()
+
+if(_Ruby_DEBUG_OUTPUT)
+  message("Ruby_FIND_VERSION=${Ruby_FIND_VERSION}")
+  message("Ruby_FIND_VERSION_MAJOR=${Ruby_FIND_VERSION_MAJOR}")
+  message("Ruby_FIND_VERSION_MINOR=${Ruby_FIND_VERSION_MINOR}")
+  message("Ruby_FIND_VERSION_PATCH=${Ruby_FIND_VERSION_PATCH}")
+endif()
+
+set(Ruby_FIND_VERSION_SHORT_NODOT "${Ruby_FIND_VERSION_MAJOR}${Ruby_FIND_VERSION_MINOR}")
+
+# Set name of possible executables, ignoring the minor
+# Eg:
+# 2.1.1 => from ruby27 to ruby21 included
+# 2.1   => from ruby27 to ruby21 included
+# 2     => from ruby26 to ruby20 included
+# empty => from ruby27 to ruby18 included
+if(NOT Ruby_FIND_VERSION_EXACT)
+
+  foreach(_ruby_version RANGE 27 18 -1)
+    string(SUBSTRING "${_ruby_version}" 0 1 _ruby_major_version)
+    string(SUBSTRING "${_ruby_version}" 1 1 _ruby_minor_version)
+
+    if(NOT "${_ruby_major_version}${_ruby_minor_version}" VERSION_LESS ${Ruby_FIND_VERSION_SHORT_NODOT})
+      # Append both rubyX.Y and rubyXY (eg: ruby2.7 ruby27)
+      list(APPEND _Ruby_POSSIBLE_EXECUTABLE_NAMES ruby${_ruby_major_version}.${_ruby_minor_version} ruby${_ruby_major_version}${_ruby_minor_version})
+    else()
+      break()
+    endif()
+
+  endforeach()
+
+  list(REMOVE_DUPLICATES _Ruby_POSSIBLE_EXECUTABLE_NAMES)
+endif()
+
+# virtual environments handling (eg RVM)
+if (DEFINED ENV{MY_RUBY_HOME})
+  if(_Ruby_DEBUG_OUTPUT)
+    message("My ruby home is defined: $ENV{MY_RUBY_HOME}")
+  endif()
+
+  if (DEFINED Ruby_FIND_VIRTUALENV)
+    if (NOT Ruby_FIND_VIRTUALENV MATCHES "^(FIRST|ONLY|STANDARD)$")
+      message (AUTHOR_WARNING "FindRuby: ${Ruby_FIND_VIRTUALENV}: invalid value for 'Ruby_FIND_VIRTUALENV'. 'FIRST', 'ONLY' or 'STANDARD' expected. 'FIRST' will be used instead.")
+      set (_Ruby_FIND_VIRTUALENV "FIRST")
+    else()
+      set (_Ruby_FIND_VIRTUALENV ${Ruby_FIND_VIRTUALENV})
+    endif()
+  else()
+    set (_Ruby_FIND_VIRTUALENV FIRST)
+  endif()
+else()
+  if (DEFINED Ruby_FIND_VIRTUALENV)
+    message("Environment variable MY_RUBY_HOME isn't set, defaulting back to Ruby_FIND_VIRTUALENV=STANDARD")
+  endif()
+  set (_Ruby_FIND_VIRTUALENV STANDARD)
+endif()
+
+if(_Ruby_DEBUG_OUTPUT)
+  message("_Ruby_POSSIBLE_EXECUTABLE_NAMES=${_Ruby_POSSIBLE_EXECUTABLE_NAMES}")
+  message("_Ruby_FIND_VIRTUALENV=${_Ruby_FIND_VIRTUALENV}")
+endif()
+
+function (_RUBY_VALIDATE_INTERPRETER)
+  if (NOT Ruby_EXECUTABLE)
+    return()
+  endif()
+
+  cmake_parse_arguments (PARSE_ARGV 0 _RVI "EXACT;CHECK_EXISTS" "" "")
+  if (_RVI_UNPARSED_ARGUMENTS)
+    set (expected_version ${_RVI_UNPARSED_ARGUMENTS})
+  else()
+    unset (expected_version)
+  endif()
+
+  if (_RVI_CHECK_EXISTS AND NOT EXISTS "${Ruby_EXECUTABLE}")
+    # interpreter does not exist anymore
+    set (_Ruby_Interpreter_REASON_FAILURE "Cannot find the interpreter \"${Ruby_EXECUTABLE}\"")
+    set_property (CACHE Ruby_EXECUTABLE PROPERTY VALUE "Ruby_EXECUTABLE-NOTFOUND")
+    return()
+  endif()
+
+  # Check the version it returns
+  # executable found must have a specific version
+  execute_process (COMMAND "${Ruby_EXECUTABLE}" -e "puts RUBY_VERSION"
+                   RESULT_VARIABLE result
+                   OUTPUT_VARIABLE version
+                   ERROR_QUIET
+                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (result OR (_RVI_EXACT AND NOT version VERSION_EQUAL expected_version) OR (version VERSION_LESS expected_version))
+    # interpreter not usable or has wrong major version
+    if (result)
+      set (_Ruby_Interpreter_REASON_FAILURE "Cannot use the interpreter \"${Ruby_EXECUTABLE}\"")
+    else()
+      set (_Ruby_Interpreter_REASON_FAILURE "Wrong major version for the interpreter \"${Ruby_EXECUTABLE}\"")
+    endif()
+    set_property (CACHE Ruby_EXECUTABLE PROPERTY VALUE "Ruby_EXECUTABLE-NOTFOUND")
+    return()
+  endif()
+
+endfunction()
+
+while(1)
+  # Virtual environments handling
+  if(_Ruby_FIND_VIRTUALENV MATCHES "^(FIRST|ONLY)$")
+    if(_Ruby_DEBUG_OUTPUT)
+      message("Inside Matches")
+    endif()
+    find_program (Ruby_EXECUTABLE
+                  NAMES ${_Ruby_POSSIBLE_EXECUTABLE_NAMES}
+                  NAMES_PER_DIR
+                  PATHS ENV MY_RUBY_HOME
+                  PATH_SUFFIXES bin Scripts
+                  NO_CMAKE_PATH
+                  NO_CMAKE_ENVIRONMENT_PATH
+                  NO_SYSTEM_ENVIRONMENT_PATH
+                  NO_CMAKE_SYSTEM_PATH)
+
+    if(_Ruby_DEBUG_OUTPUT)
+      message("Ruby_EXECUTABLE=${Ruby_EXECUTABLE}")
+    endif()
+
+    _RUBY_VALIDATE_INTERPRETER (${Ruby_FIND_VERSION}})
+    if(Ruby_EXECUTABLE)
+      break()
+    endif()
+    if(NOT _Ruby_FIND_VIRTUALENV STREQUAL "ONLY")
+      break()
+    endif()
+  elseif(_Ruby_DEBUG_OUTPUT)
+    message("_Ruby_FIND_VIRTUALENV doesn't match: ${_Ruby_FIND_VIRTUALENV}")
+  endif()
+
+  # try using standard paths
+  find_program (Ruby_EXECUTABLE
+                NAMES ${_Ruby_POSSIBLE_EXECUTABLE_NAMES}
+                NAMES_PER_DIR)
+  _RUBY_VALIDATE_INTERPRETER (${Ruby_FIND_VERSION})
+  if (Ruby_EXECUTABLE)
+    break()
+  endif()
+
+  break()
+endwhile()
+
+if(Ruby_EXECUTABLE AND NOT Ruby_VERSION_MAJOR)
+  function(_RUBY_CONFIG_VAR RBVAR OUTVAR)
+    execute_process(COMMAND ${Ruby_EXECUTABLE} -r rbconfig -e "print RbConfig::CONFIG['${RBVAR}']"
+      RESULT_VARIABLE _Ruby_SUCCESS
+      OUTPUT_VARIABLE _Ruby_OUTPUT
+      ERROR_QUIET)
+    if(_Ruby_SUCCESS OR _Ruby_OUTPUT STREQUAL "")
+      execute_process(COMMAND ${Ruby_EXECUTABLE} -r rbconfig -e "print Config::CONFIG['${RBVAR}']"
+        RESULT_VARIABLE _Ruby_SUCCESS
+        OUTPUT_VARIABLE _Ruby_OUTPUT
+        ERROR_QUIET)
+    endif()
+    set(${OUTVAR} "${_Ruby_OUTPUT}" PARENT_SCOPE)
+  endfunction()
+
+
+  # query the ruby version
+  _RUBY_CONFIG_VAR("MAJOR" Ruby_VERSION_MAJOR)
+  _RUBY_CONFIG_VAR("MINOR" Ruby_VERSION_MINOR)
+  _RUBY_CONFIG_VAR("TEENY" Ruby_VERSION_PATCH)
+
+  # query the different directories
+  _RUBY_CONFIG_VAR("archdir" Ruby_ARCH_DIR)
+  _RUBY_CONFIG_VAR("arch" Ruby_ARCH)
+  _RUBY_CONFIG_VAR("rubyhdrdir" Ruby_HDR_DIR)
+  _RUBY_CONFIG_VAR("rubyarchhdrdir" Ruby_ARCHHDR_DIR)
+  _RUBY_CONFIG_VAR("libdir" Ruby_POSSIBLE_LIB_DIR)
+  _RUBY_CONFIG_VAR("rubylibdir" Ruby_RUBY_LIB_DIR)
+
+  # site_ruby
+  _RUBY_CONFIG_VAR("sitearchdir" Ruby_SITEARCH_DIR)
+  _RUBY_CONFIG_VAR("sitelibdir" Ruby_SITELIB_DIR)
+
+  # vendor_ruby available ?
+  execute_process(COMMAND ${Ruby_EXECUTABLE} -r vendor-specific -e "print 'true'"
+    OUTPUT_VARIABLE Ruby_HAS_VENDOR_RUBY  ERROR_QUIET)
+
+  if(Ruby_HAS_VENDOR_RUBY)
+    _RUBY_CONFIG_VAR("vendorlibdir" Ruby_VENDORLIB_DIR)
+    _RUBY_CONFIG_VAR("vendorarchdir" Ruby_VENDORARCH_DIR)
+  endif()
+
+  # save the results in the cache so we don't have to run ruby the next time again
+  set(Ruby_VERSION_MAJOR    ${Ruby_VERSION_MAJOR}    CACHE PATH "The Ruby major version" FORCE)
+  set(Ruby_VERSION_MINOR    ${Ruby_VERSION_MINOR}    CACHE PATH "The Ruby minor version" FORCE)
+  set(Ruby_VERSION_PATCH    ${Ruby_VERSION_PATCH}    CACHE PATH "The Ruby patch version" FORCE)
+  set(Ruby_ARCH_DIR         ${Ruby_ARCH_DIR}         CACHE PATH "The Ruby arch dir" FORCE)
+  set(Ruby_HDR_DIR          ${Ruby_HDR_DIR}          CACHE PATH "The Ruby header dir (1.9+)" FORCE)
+  set(Ruby_ARCHHDR_DIR      ${Ruby_ARCHHDR_DIR}      CACHE PATH "The Ruby arch header dir (2.0+)" FORCE)
+  set(Ruby_POSSIBLE_LIB_DIR ${Ruby_POSSIBLE_LIB_DIR} CACHE PATH "The Ruby lib dir" FORCE)
+  set(Ruby_RUBY_LIB_DIR     ${Ruby_RUBY_LIB_DIR}     CACHE PATH "The Ruby ruby-lib dir" FORCE)
+  set(Ruby_SITEARCH_DIR     ${Ruby_SITEARCH_DIR}     CACHE PATH "The Ruby site arch dir" FORCE)
+  set(Ruby_SITELIB_DIR      ${Ruby_SITELIB_DIR}      CACHE PATH "The Ruby site lib dir" FORCE)
+  set(Ruby_HAS_VENDOR_RUBY  ${Ruby_HAS_VENDOR_RUBY}  CACHE BOOL "Vendor Ruby is available" FORCE)
+  set(Ruby_VENDORARCH_DIR   ${Ruby_VENDORARCH_DIR}   CACHE PATH "The Ruby vendor arch dir" FORCE)
+  set(Ruby_VENDORLIB_DIR    ${Ruby_VENDORLIB_DIR}    CACHE PATH "The Ruby vendor lib dir" FORCE)
+
+  mark_as_advanced(
+    Ruby_ARCH_DIR
+    Ruby_ARCH
+    Ruby_HDR_DIR
+    Ruby_ARCHHDR_DIR
+    Ruby_POSSIBLE_LIB_DIR
+    Ruby_RUBY_LIB_DIR
+    Ruby_SITEARCH_DIR
+    Ruby_SITELIB_DIR
+    Ruby_HAS_VENDOR_RUBY
+    Ruby_VENDORARCH_DIR
+    Ruby_VENDORLIB_DIR
+    Ruby_VERSION_MAJOR
+    Ruby_VERSION_MINOR
+    Ruby_VERSION_PATCH
+    )
+endif()
+
+# In case Ruby_EXECUTABLE could not be executed (e.g. cross compiling)
+# try to detect which version we found. This is not too good.
+if(Ruby_EXECUTABLE AND NOT Ruby_VERSION_MAJOR)
+  # by default assume 1.8.0
+  set(Ruby_VERSION_MAJOR 1)
+  set(Ruby_VERSION_MINOR 8)
+  set(Ruby_VERSION_PATCH 0)
+  # check whether we found 1.9.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby1\\.?9")
+    set(Ruby_VERSION_MAJOR 1)
+    set(Ruby_VERSION_MINOR 9)
+  endif()
+  # check whether we found 2.0.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby2\\.?0")
+    set(Ruby_VERSION_MAJOR 2)
+    set(Ruby_VERSION_MINOR 0)
+  endif()
+  # check whether we found 2.1.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby2\\.?1")
+    set(Ruby_VERSION_MAJOR 2)
+    set(Ruby_VERSION_MINOR 1)
+  endif()
+  # check whether we found 2.2.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby2\\.?2")
+    set(Ruby_VERSION_MAJOR 2)
+    set(Ruby_VERSION_MINOR 2)
+  endif()
+  # check whether we found 2.3.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby2\\.?3")
+    set(Ruby_VERSION_MAJOR 2)
+    set(Ruby_VERSION_MINOR 3)
+  endif()
+  # check whether we found 2.4.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby2\\.?4")
+    set(Ruby_VERSION_MAJOR 2)
+    set(Ruby_VERSION_MINOR 4)
+  endif()
+  # check whether we found 2.5.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby2\\.?5")
+    set(Ruby_VERSION_MAJOR 2)
+    set(Ruby_VERSION_MINOR 5)
+  endif()
+  # check whether we found 2.6.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby2\\.?6")
+    set(Ruby_VERSION_MAJOR 2)
+    set(Ruby_VERSION_MINOR 6)
+  endif()
+  # check whether we found 2.7.x
+  if(${Ruby_EXECUTABLE} MATCHES "ruby2\\.?7")
+    set(Ruby_VERSION_MAJOR 2)
+    set(Ruby_VERSION_MINOR 7)
+  endif()
+endif()
+
+if(Ruby_VERSION_MAJOR)
+  set(Ruby_VERSION "${Ruby_VERSION_MAJOR}.${Ruby_VERSION_MINOR}.${Ruby_VERSION_PATCH}")
+  set(_Ruby_VERSION_SHORT "${Ruby_VERSION_MAJOR}.${Ruby_VERSION_MINOR}")
+  set(_Ruby_VERSION_SHORT_NODOT "${Ruby_VERSION_MAJOR}${Ruby_VERSION_MINOR}")
+  set(_Ruby_NODOT_VERSION "${Ruby_VERSION_MAJOR}${Ruby_VERSION_MINOR}${Ruby_VERSION_PATCH}")
+endif()
+
+# FIXME: Currently we require both the interpreter and development components to be found
+# in order to use either.  See issue #20474.
+find_path(Ruby_INCLUDE_DIR
+  NAMES ruby.h
+  HINTS
+    ${Ruby_HDR_DIR}
+    ${Ruby_ARCH_DIR}
+    /usr/lib/ruby/${_Ruby_VERSION_SHORT}/i586-linux-gnu/
+)
+
+set(Ruby_INCLUDE_DIRS ${Ruby_INCLUDE_DIR})
+
+# if ruby > 1.8 is required or if ruby > 1.8 was found, search for the config.h dir
+if( Ruby_FIND_VERSION VERSION_GREATER_EQUAL "1.9"  OR  Ruby_VERSION VERSION_GREATER_EQUAL "1.9"  OR  Ruby_HDR_DIR)
+  find_path(Ruby_CONFIG_INCLUDE_DIR
+    NAMES ruby/config.h  config.h
+    HINTS
+      ${Ruby_HDR_DIR}/${Ruby_ARCH}
+      ${Ruby_ARCH_DIR}
+      ${Ruby_ARCHHDR_DIR}
+  )
+
+  set(Ruby_INCLUDE_DIRS ${Ruby_INCLUDE_DIRS} ${Ruby_CONFIG_INCLUDE_DIR} )
+endif()
+
+
+# Determine the list of possible names for the ruby library
+set(_Ruby_POSSIBLE_LIB_NAMES ruby ruby-static ruby${_Ruby_VERSION_SHORT} ruby${_Ruby_VERSION_SHORT_NODOT} ruby-${_Ruby_VERSION_SHORT} ruby-${Ruby_VERSION})
+
+if(WIN32)
+  if(MSVC_TOOLSET_VERSION)
+    set(_Ruby_MSVC_RUNTIME "${MSVC_TOOLSET_VERSION}")
+  else()
+    set(_Ruby_MSVC_RUNTIME "")
+  endif()
+
+  set(_Ruby_ARCH_PREFIX "")
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_Ruby_ARCH_PREFIX "x64-")
+  endif()
+
+  list(APPEND _Ruby_POSSIBLE_LIB_NAMES
+             "${_Ruby_ARCH_PREFIX}msvcr${_Ruby_MSVC_RUNTIME}-ruby${_Ruby_NODOT_VERSION}"
+             "${_Ruby_ARCH_PREFIX}msvcr${_Ruby_MSVC_RUNTIME}-ruby${_Ruby_NODOT_VERSION}-static"
+             "${_Ruby_ARCH_PREFIX}msvcrt-ruby${_Ruby_NODOT_VERSION}"
+             "${_Ruby_ARCH_PREFIX}msvcrt-ruby${_Ruby_NODOT_VERSION}-static" )
+endif()
+
+find_library(Ruby_LIBRARY NAMES ${_Ruby_POSSIBLE_LIB_NAMES} HINTS ${Ruby_POSSIBLE_LIB_DIR} )
+
+set(_Ruby_REQUIRED_VARS Ruby_EXECUTABLE Ruby_INCLUDE_DIR Ruby_LIBRARY)
+if(_Ruby_VERSION_SHORT_NODOT GREATER 18)
+  list(APPEND _Ruby_REQUIRED_VARS Ruby_CONFIG_INCLUDE_DIR)
+endif()
+
+if(_Ruby_DEBUG_OUTPUT)
+  message(STATUS "--------FindRuby.cmake debug------------")
+  message(STATUS "_Ruby_POSSIBLE_EXECUTABLE_NAMES: ${_Ruby_POSSIBLE_EXECUTABLE_NAMES}")
+  message(STATUS "_Ruby_POSSIBLE_LIB_NAMES: ${_Ruby_POSSIBLE_LIB_NAMES}")
+  message(STATUS "Ruby_ARCH_DIR: ${Ruby_ARCH_DIR}")
+  message(STATUS "Ruby_HDR_DIR: ${Ruby_HDR_DIR}")
+  message(STATUS "Ruby_POSSIBLE_LIB_DIR: ${Ruby_POSSIBLE_LIB_DIR}")
+  message(STATUS "Found Ruby_VERSION: \"${Ruby_VERSION}\" , short: \"${_Ruby_VERSION_SHORT}\", nodot: \"${_Ruby_VERSION_SHORT_NODOT}\"")
+  message(STATUS "_Ruby_REQUIRED_VARS: ${_Ruby_REQUIRED_VARS}")
+  message(STATUS "Ruby_EXECUTABLE: ${Ruby_EXECUTABLE}")
+  message(STATUS "Ruby_LIBRARY: ${Ruby_LIBRARY}")
+  message(STATUS "Ruby_INCLUDE_DIR: ${Ruby_INCLUDE_DIR}")
+  message(STATUS "Ruby_CONFIG_INCLUDE_DIR: ${Ruby_CONFIG_INCLUDE_DIR}")
+  message(STATUS "--------------------")
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Ruby  REQUIRED_VARS  ${_Ruby_REQUIRED_VARS}
+                                        VERSION_VAR Ruby_VERSION )
+
+if(Ruby_FOUND)
+  set(Ruby_LIBRARIES ${Ruby_LIBRARY})
+endif()
+
+mark_as_advanced(
+  Ruby_EXECUTABLE
+  Ruby_LIBRARY
+  Ruby_INCLUDE_DIR
+  Ruby_CONFIG_INCLUDE_DIR
+  )
+
+# Set some variables for compatibility with previous version of this file (no need to provide a CamelCase version of that...)
+set(RUBY_POSSIBLE_LIB_PATH ${Ruby_POSSIBLE_LIB_DIR})
+set(RUBY_RUBY_LIB_PATH ${Ruby_RUBY_LIB_DIR})
+set(RUBY_INCLUDE_PATH ${Ruby_INCLUDE_DIRS})
+
+# Backwards compatibility
+# Define upper case versions of output variables
+foreach(Camel
+    Ruby_EXECUTABLE
+    Ruby_INCLUDE_DIRS
+    Ruby_LIBRARY
+    Ruby_VERSION
+    Ruby_VERSION_MAJOR
+    Ruby_VERSION_MINOR
+    Ruby_VERSION_PATCH
+
+    Ruby_ARCH_DIR
+    Ruby_ARCH
+    Ruby_HDR_DIR
+    Ruby_ARCHHDR_DIR
+    Ruby_POSSIBLE_LIB_DIR
+    Ruby_RUBY_LIB_DIR
+    Ruby_SITEARCH_DIR
+    Ruby_SITELIB_DIR
+    Ruby_HAS_VENDOR_RUBY
+    Ruby_VENDORARCH_DIR
+
+    )
+    string(TOUPPER ${Camel} UPPER)
+    set(${UPPER} ${${Camel}})
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,8 @@ endif()
 
 option(BUILD_PACKAGE "Build package" OFF)
 
+option(BUILD_TESTING "Build testing" OFF)
+
 # DView
 # option(BUILD_DVIEW "Build DView" OFF)
 

--- a/FindOpenStudioSDK.cmake
+++ b/FindOpenStudioSDK.cmake
@@ -110,13 +110,20 @@ else()
             message(STATUS "Download OpenStudio SDK is a success, from: ${OPENSTUDIO_URL}")
             break()
           else()
-            message(FATAL_ERROR
+            set(ERROR_MSG
               "Download seemed to have worked, but archive md5sum HASH mismatch\n"
               "     for file: ${OPENSTUDIO_ARCHIVE_DIR}/${OPENSTUDIO_ARCHIVE_NAME}\n"
               "     from URL: ${OPENSTUDIO_URL}\n"
               "       expected hash: [${OPENSTUDIO_EXPECTED_HASH}]\n"
               "         actual hash: [${OPENSTUDIO_HASH}]\n"
             )
+            # If official => FATAL_ERROR. If CI build, it's possibe the package is overriden by nightly build if the SHA of develop is the same as the
+            # day before, so only warn
+            if (BASELINK STREQUAL OPENSTUDIO_BASELINK_RELEASE)
+              message(FATAL_ERROR "${ERROR_MSG}")
+            else()
+              message(AUTHOR_WARNING "${ERROR_MSG}")
+            endif()
           endif()
         endif()
       endif()

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -117,36 +117,39 @@ file(GLOB RUBY_TEST_SRC "test/*.rb")
 # TODO: It doesn't work with this executable that's in build/Ruby-install/bin
 # message("RUBY_EXECUTABLE=${RUBY_EXECUTABLE}")
 
-# I added FindRuby.cmake from cmake 3.18.2 (after patching cmake to support versiosn greater than 2 and adding RVM support) in the CMake folder which is part of the CMAKE_MODULE_PATH
-set (Ruby_FIND_VIRTUALENV FIRST)
-find_package(Ruby 2.5 REQUIRED)
-
-set(_RUBY_POSSIBLE_EXECUTABLE_NAMES
-  ruby
-  ruby2.5
-  ruby2.5.1
-  ruby25
-  ruby251)
-
+# I added FindRuby.cmake from cmake 3.18.2 (after patching cmake to support versions greater than 2 and adding RVM support) in the CMake folder which is part of the CMAKE_MODULE_PATH
+set(Ruby_FIND_VIRTUALENV FIRST)
+find_package(Ruby 2.5)
 
 if(NOT Ruby_FOUND)
   message(WARNING "Your system ruby wasn't found, you won't be able to run the `ctest -R RubyTest` command and the tests won't be created at all.")
 else()
   message(STATUS "Found Ruby_EXECUTABLE=${Ruby_EXECUTABLE}")
+endif()
 
-  # add a test for each unit test
-  set(RUBY_TEST_REQUIRES "#include test files")
-  foreach(f ${RUBY_TEST_SRC})
+# add a test for each unit test
+set(RUBY_TEST_REQUIRES "#include test files")
+foreach(f ${RUBY_TEST_SRC})
 
-    file(READ "${f}" CONTENTS)
-    string(REGEX MATCHALL "def +test_([A-Za-z_0-9 ]+)" FOUND_TESTS ${CONTENTS})
+  file(READ "${f}" CONTENTS)
+  string(REGEX MATCHALL "def +test_([A-Za-z_0-9 ]+)" FOUND_TESTS ${CONTENTS})
 
-    foreach(HIT ${FOUND_TESTS})
-      string(REGEX REPLACE "def +test_([A-Za-z_0-9]+)" "\\1" TEST_NAME ${HIT})
-      string(REGEX MATCH "/?([A-Za-z_0-9 ]+)\\.rb" FILE_NAME ${f})
-      string(REGEX REPLACE "/?([A-Za-z_0-9 ]+)\\.rb" "\\1" FILE_NAME ${FILE_NAME})
-      if(BUILD_TESTING)
+  foreach(HIT ${FOUND_TESTS})
+    string(REGEX REPLACE "def +test_([A-Za-z_0-9]+)" "\\1" TEST_NAME ${HIT})
+    string(REGEX MATCH "/?([A-Za-z_0-9 ]+)\\.rb" FILE_NAME ${f})
+    string(REGEX REPLACE "/?([A-Za-z_0-9 ]+)\\.rb" "\\1" FILE_NAME ${FILE_NAME})
+    if(BUILD_TESTING)
 
+      # CLI Test
+      add_test(NAME "OSApp-CLITest-${FILE_NAME}-${TEST_NAME}"
+        COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
+          "${openstudio_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
+                               "${f}" "--name=test_${TEST_NAME}"
+      )
+
+      set_tests_properties("OSApp-CLITest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )
+
+      if (Ruby_FOUND)
         # Call with Ruby itself
         add_test(NAME "OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}"
           COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
@@ -157,7 +160,9 @@ else()
 
         set_tests_properties("OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )
       endif()
-    endforeach()
+
+    endif()
   endforeach()
+endforeach()
 
 endif()

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -146,7 +146,7 @@ if(BUILD_TESTING)
       add_test(NAME "OSApp-CLITest-${FILE_NAME}-${TEST_NAME}"
         COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
           "${openstudio_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
-                               "${f}" "--name=test_${TEST_NAME}"
+          "${f}" "--name=test_${TEST_NAME}"
       )
 
       set_tests_properties("OSApp-CLITest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )
@@ -156,8 +156,8 @@ if(BUILD_TESTING)
         add_test(NAME "OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}"
           COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
             "${Ruby_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio::openstudio_rb>" # Or just ${openstudio_ROOT_DIR}/Ruby
-                                 "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
-                                 "${f}" "--name=test_${TEST_NAME}"
+            "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
+            "${f}" "--name=test_${TEST_NAME}"
         )
 
         set_tests_properties("OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -24,7 +24,6 @@ target_include_directories(openstudio_modeleditor_rb PRIVATE ${RUBY_INCLUDE_DIRS
 set_target_properties(openstudio_modeleditor_rb PROPERTIES PREFIX "")
 set_target_properties(openstudio_modeleditor_rb PROPERTIES OUTPUT_NAME openstudio_modeleditor)
 
-# TODO: Output directly to Products/openstudio/ruby so it sits next to openstudio.so and others? `${PROJECT_BINARY_DIR}/openstudio/Products/ruby/`
 set_target_properties(openstudio_modeleditor_rb PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/ruby/")
 set_target_properties(openstudio_modeleditor_rb PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ruby/")
 set_target_properties(openstudio_modeleditor_rb PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ruby/")

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -141,15 +141,15 @@ if(BUILD_TESTING)
       string(REGEX MATCH "/?([A-Za-z_0-9 ]+)\\.rb" FILE_NAME ${f})
       string(REGEX REPLACE "/?([A-Za-z_0-9 ]+)\\.rb" "\\1" FILE_NAME ${FILE_NAME})
 
-
+      # DLM: Cannot load openstudio_modeleditor.so into CLI because linked with different version of Ruby
       # CLI Test
-      add_test(NAME "OSApp-CLITest-${FILE_NAME}-${TEST_NAME}"
-        COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
-          "${openstudio_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
-          "${f}" "--name=test_${TEST_NAME}"
-      )
+      #add_test(NAME "OSApp-CLITest-${FILE_NAME}-${TEST_NAME}"
+      #  COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
+      #    "${openstudio_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
+      #    "${f}" "--name=test_${TEST_NAME}"
+      #)
 
-      set_tests_properties("OSApp-CLITest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )
+      #set_tests_properties("OSApp-CLITest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )
 
       if (Ruby_EXECUTABLE)
         # Call with Ruby itself

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -111,34 +111,36 @@ endif()
 #                        T E S T I N G:   C T E S T S                         #
 ###############################################################################
 
-# find all tests
-file(GLOB RUBY_TEST_SRC "test/*.rb")
+if(BUILD_TESTING)
 
-# TODO: It doesn't work with this executable that's in build/Ruby-install/bin
-# message("RUBY_EXECUTABLE=${RUBY_EXECUTABLE}")
+  # find all tests
+  file(GLOB RUBY_TEST_SRC "test/*.rb")
 
-# I added FindRuby.cmake from cmake 3.18.2 (after patching cmake to support versions greater than 2 and adding RVM support) in the CMake folder which is part of the CMAKE_MODULE_PATH
-set(Ruby_FIND_VIRTUALENV FIRST)
-find_package(Ruby 2.5)
+  # TODO: It doesn't work with this executable that's in build/Ruby-install/bin
+  # message("RUBY_EXECUTABLE=${RUBY_EXECUTABLE}")
 
-if(NOT Ruby_FOUND)
-  message(WARNING "Your system ruby wasn't found, you won't be able to run the `ctest -R RubyTest` command and the tests won't be created at all.")
-else()
-  message(STATUS "Found Ruby_EXECUTABLE=${Ruby_EXECUTABLE}")
-endif()
+  # I added FindRuby.cmake from cmake 3.18.2 (after patching cmake to support versions greater than 2 and adding RVM support) in the CMake folder which is part of the CMAKE_MODULE_PATH
+  set(Ruby_FIND_VIRTUALENV FIRST)
+  find_package(Ruby 2.5)
 
-# add a test for each unit test
-set(RUBY_TEST_REQUIRES "#include test files")
-foreach(f ${RUBY_TEST_SRC})
+  if(NOT Ruby_FOUND)
+    message(WARNING "Your system ruby wasn't found, you won't be able to run the `ctest -R RubyTest` command and the tests won't be created at all.")
+  else()
+    message(STATUS "Found Ruby_EXECUTABLE=${Ruby_EXECUTABLE}")
+  endif()
 
-  file(READ "${f}" CONTENTS)
-  string(REGEX MATCHALL "def +test_([A-Za-z_0-9 ]+)" FOUND_TESTS ${CONTENTS})
+  # add a test for each unit test
+  set(RUBY_TEST_REQUIRES "#include test files")
+  foreach(f ${RUBY_TEST_SRC})
 
-  foreach(HIT ${FOUND_TESTS})
-    string(REGEX REPLACE "def +test_([A-Za-z_0-9]+)" "\\1" TEST_NAME ${HIT})
-    string(REGEX MATCH "/?([A-Za-z_0-9 ]+)\\.rb" FILE_NAME ${f})
-    string(REGEX REPLACE "/?([A-Za-z_0-9 ]+)\\.rb" "\\1" FILE_NAME ${FILE_NAME})
-    if(BUILD_TESTING)
+    file(READ "${f}" CONTENTS)
+    string(REGEX MATCHALL "def +test_([A-Za-z_0-9 ]+)" FOUND_TESTS ${CONTENTS})
+
+    foreach(HIT ${FOUND_TESTS})
+      string(REGEX REPLACE "def +test_([A-Za-z_0-9]+)" "\\1" TEST_NAME ${HIT})
+      string(REGEX MATCH "/?([A-Za-z_0-9 ]+)\\.rb" FILE_NAME ${f})
+      string(REGEX REPLACE "/?([A-Za-z_0-9 ]+)\\.rb" "\\1" FILE_NAME ${FILE_NAME})
+
 
       # CLI Test
       add_test(NAME "OSApp-CLITest-${FILE_NAME}-${TEST_NAME}"
@@ -161,8 +163,6 @@ foreach(f ${RUBY_TEST_SRC})
         set_tests_properties("OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )
       endif()
 
-    endif()
+    endforeach()
   endforeach()
-endforeach()
-
 endif()

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -123,7 +123,7 @@ if(BUILD_TESTING)
   set(Ruby_FIND_VIRTUALENV FIRST)
   find_package(Ruby 2.5)
 
-  if(NOT Ruby_FOUND)
+  if(NOT Ruby_EXECUTABLE)
     message(WARNING "Your system ruby wasn't found, you won't be able to run the `ctest -R RubyTest` command and the tests won't be created at all.")
   else()
     message(STATUS "Found Ruby_EXECUTABLE=${Ruby_EXECUTABLE}")
@@ -151,7 +151,7 @@ if(BUILD_TESTING)
 
       set_tests_properties("OSApp-CLITest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )
 
-      if (Ruby_FOUND)
+      if (Ruby_EXECUTABLE)
         # Call with Ruby itself
         add_test(NAME "OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}"
           COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -24,6 +24,7 @@ target_include_directories(openstudio_modeleditor_rb PRIVATE ${RUBY_INCLUDE_DIRS
 set_target_properties(openstudio_modeleditor_rb PROPERTIES PREFIX "")
 set_target_properties(openstudio_modeleditor_rb PROPERTIES OUTPUT_NAME openstudio_modeleditor)
 
+# TODO: Output directly to Products/openstudio/ruby so it sits next to openstudio.so and others? `${PROJECT_BINARY_DIR}/openstudio/Products/ruby/`
 set_target_properties(openstudio_modeleditor_rb PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/ruby/")
 set_target_properties(openstudio_modeleditor_rb PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ruby/")
 set_target_properties(openstudio_modeleditor_rb PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ruby/")
@@ -104,4 +105,71 @@ endif()
 
 if( BUILD_PAT )
   # don't need modeleditor libs in pat
+endif()
+
+###############################################################################
+#                        T E S T I N G:   C T E S T S                         #
+###############################################################################
+
+# find all tests
+file(GLOB RUBY_TEST_SRC "test/*.rb")
+
+# TODO: It doesn't not work with this executable that's in build/Ruby-install/bin
+# message("RUBY_EXECUTABLE=${RUBY_EXECUTABLE}")
+
+set(_RUBY_POSSIBLE_EXECUTABLE_NAMES
+  ruby
+  ruby2.5
+  ruby2.5.1
+  ruby25
+  ruby251)
+
+# TODO: this isn't great but I haven't found a better way to locate the system ruby (and avoid the one in build/Ruby-install/)
+find_program(SYSTEM_RUBY_EXECUTABLE NAMES ${_RUBY_POSSIBLE_EXECUTABLE_NAMES}
+  HINTS
+    "/usr"
+    "/usr/local"
+    "/usr/share/rvm/rubies/ruby-2.5.1/bin/"
+    "/usr/share/rvm/rubies/ruby-2.5.2/bin/"
+    "/usr/share/rvm/rubies/ruby-2.5.3/bin/"
+    "/usr/share/rvm/rubies/ruby-2.5.4/bin/"
+    "/usr/share/rvm/rubies/ruby-2.5.5/bin/"
+    "$ENV{HOME}/.rvm/rubies/ruby-2.5.1/bin/"
+    "$ENV{HOME}/.rvm/rubies/ruby-2.5.2/bin/"
+    "$ENV{HOME}/.rvm/rubies/ruby-2.5.3/bin/"
+    "$ENV{HOME}/.rvm/rubies/ruby-2.5.4/bin/"
+    "$ENV{HOME}/.rvm/rubies/ruby-2.5.5/bin/"
+    "C:/Ruby25-x64/bin/"
+  NO_DEFAULT_PATH)
+
+if(NOT SYSTEM_RUBY_EXECUTABLE)
+  message(WARNING "Your system ruby wasn't found, you won't be able to run the `ctest -R RubyTest` command and the tests won't be created at all.")
+else()
+  message(STATUS "Found SYSTEM_RUBY_EXECUTABLE=${SYSTEM_RUBY_EXECUTABLE}")
+
+  # add a test for each unit test
+  set(RUBY_TEST_REQUIRES "#include test files")
+  foreach(f ${RUBY_TEST_SRC})
+
+    file(READ "${f}" CONTENTS)
+    string(REGEX MATCHALL "def +test_([A-Za-z_0-9 ]+)" FOUND_TESTS ${CONTENTS})
+
+    foreach(HIT ${FOUND_TESTS})
+      string(REGEX REPLACE "def +test_([A-Za-z_0-9]+)" "\\1" TEST_NAME ${HIT})
+      string(REGEX MATCH "/?([A-Za-z_0-9 ]+)\\.rb" FILE_NAME ${f})
+      string(REGEX REPLACE "/?([A-Za-z_0-9 ]+)\\.rb" "\\1" FILE_NAME ${FILE_NAME})
+      if(BUILD_TESTING)
+
+        # Call with Ruby itself
+        # TODO: might need -I openstudio_modeleditor_rb instead/as well.
+        add_test(NAME "OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}"
+          COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
+          "${SYSTEM_RUBY_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio_rb>" "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>" "${f}" "--name=test_${TEST_NAME}"
+        )
+
+        set_tests_properties("OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )
+      endif()
+    endforeach()
+  endforeach()
+
 endif()

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -114,8 +114,12 @@ endif()
 # find all tests
 file(GLOB RUBY_TEST_SRC "test/*.rb")
 
-# TODO: It doesn't not work with this executable that's in build/Ruby-install/bin
+# TODO: It doesn't work with this executable that's in build/Ruby-install/bin
 # message("RUBY_EXECUTABLE=${RUBY_EXECUTABLE}")
+
+# I added FindRuby.cmake from cmake 3.18.2 (after patching cmake to support versiosn greater than 2 and adding RVM support) in the CMake folder which is part of the CMAKE_MODULE_PATH
+set (Ruby_FIND_VIRTUALENV FIRST)
+find_package(Ruby 2.5 REQUIRED)
 
 set(_RUBY_POSSIBLE_EXECUTABLE_NAMES
   ruby
@@ -124,28 +128,11 @@ set(_RUBY_POSSIBLE_EXECUTABLE_NAMES
   ruby25
   ruby251)
 
-# TODO: this isn't great but I haven't found a better way to locate the system ruby (and avoid the one in build/Ruby-install/)
-find_program(SYSTEM_RUBY_EXECUTABLE NAMES ${_RUBY_POSSIBLE_EXECUTABLE_NAMES}
-  HINTS
-    "/usr"
-    "/usr/local"
-    "/usr/share/rvm/rubies/ruby-2.5.1/bin/"
-    "/usr/share/rvm/rubies/ruby-2.5.2/bin/"
-    "/usr/share/rvm/rubies/ruby-2.5.3/bin/"
-    "/usr/share/rvm/rubies/ruby-2.5.4/bin/"
-    "/usr/share/rvm/rubies/ruby-2.5.5/bin/"
-    "$ENV{HOME}/.rvm/rubies/ruby-2.5.1/bin/"
-    "$ENV{HOME}/.rvm/rubies/ruby-2.5.2/bin/"
-    "$ENV{HOME}/.rvm/rubies/ruby-2.5.3/bin/"
-    "$ENV{HOME}/.rvm/rubies/ruby-2.5.4/bin/"
-    "$ENV{HOME}/.rvm/rubies/ruby-2.5.5/bin/"
-    "C:/Ruby25-x64/bin/"
-  NO_DEFAULT_PATH)
 
-if(NOT SYSTEM_RUBY_EXECUTABLE)
+if(NOT Ruby_FOUND)
   message(WARNING "Your system ruby wasn't found, you won't be able to run the `ctest -R RubyTest` command and the tests won't be created at all.")
 else()
-  message(STATUS "Found SYSTEM_RUBY_EXECUTABLE=${SYSTEM_RUBY_EXECUTABLE}")
+  message(STATUS "Found Ruby_EXECUTABLE=${Ruby_EXECUTABLE}")
 
   # add a test for each unit test
   set(RUBY_TEST_REQUIRES "#include test files")
@@ -164,9 +151,9 @@ else()
         # TODO: might need -I openstudio_modeleditor_rb instead/as well.
         add_test(NAME "OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}"
           COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
-          "${SYSTEM_RUBY_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio::openstudio_rb>" # Or just ${openstudio_ROOT_DIR}/Ruby
-                                      "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
-                                      "${f}" "--name=test_${TEST_NAME}"
+            "${Ruby_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio::openstudio_rb>" # Or just ${openstudio_ROOT_DIR}/Ruby
+                                 "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
+                                 "${f}" "--name=test_${TEST_NAME}"
         )
 
         set_tests_properties("OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -148,7 +148,6 @@ else()
       if(BUILD_TESTING)
 
         # Call with Ruby itself
-        # TODO: might need -I openstudio_modeleditor_rb instead/as well.
         add_test(NAME "OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}"
           COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
             "${Ruby_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio::openstudio_rb>" # Or just ${openstudio_ROOT_DIR}/Ruby

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -164,7 +164,9 @@ else()
         # TODO: might need -I openstudio_modeleditor_rb instead/as well.
         add_test(NAME "OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}"
           COMMAND "${CMAKE_COMMAND}" -E chdir "${CMAKE_CURRENT_BINARY_DIR}"
-          "${SYSTEM_RUBY_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio_rb>" "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>" "${f}" "--name=test_${TEST_NAME}"
+          "${SYSTEM_RUBY_EXECUTABLE}" "-I" "$<TARGET_FILE_DIR:openstudio::openstudio_rb>" # Or just ${openstudio_ROOT_DIR}/Ruby
+                                      "-I" "$<TARGET_FILE_DIR:openstudio_modeleditor_rb>"
+                                      "${f}" "--name=test_${TEST_NAME}"
         )
 
         set_tests_properties("OSApp-RubyTest-${FILE_NAME}-${TEST_NAME}" PROPERTIES TIMEOUT 660 )

--- a/ruby/openstudio_modeleditor.rb
+++ b/ruby/openstudio_modeleditor.rb
@@ -49,13 +49,25 @@ if /mswin/.match(RUBY_PLATFORM) or /mingw/.match(RUBY_PLATFORM)
   WinAPI.GetDllDirectory(buffer, original_dll_directory)
 
   qt_dll_path = File.expand_path(File.join(File.dirname(__FILE__), '../bin/'))
+
+  # if install path fails, try developer paths
+  if !File.exists?(File.join(qt_dll_path, 'Qt5Core.dll'))
+    release_dll_path = File.expand_path(File.join(File.dirname(__FILE__), '../../Release/'))
+    debug_dll_path = File.expand_path(File.join(File.dirname(__FILE__), '../../Debug/'))
+    if File.exists?(File.join(release_dll_path, 'Qt5Core.dll'))
+      qt_dll_path = release_dll_path
+    elsif File.exists?(File.join(debug_dll_path, 'Qt5Core.dll'))
+      qt_dll_path = debug_dll_path
+    end
+  end
+
   WinAPI.SetDllDirectory(qt_dll_path)
 
-  $OPENSTUDIO_APPLICATION_DIR = File.join(File.dirname(__FILE__), '../bin/')
+  $OPENSTUDIO_APPLICATION_DIR = qt_dll_path
 else
 
   # Do something here for Mac OSX environments
-  qt_so_path = File.expand_path(File.join(File.dirname(__FILE__), '../bin/'))
+  qt_so_path = File.expand_path(File.join(File.dirname(__FILE__)))
   ENV['PATH'] = "#{qt_so_path}:#{original_path}"
 
   $OPENSTUDIO_APPLICATION_DIR = File.join(File.dirname(__FILE__), '../bin/')

--- a/ruby/openstudio_modeleditor.rb
+++ b/ruby/openstudio_modeleditor.rb
@@ -33,7 +33,7 @@ original_dll_directory = nil
 platform_specific_path = nil
 
 if /mswin/.match(RUBY_PLATFORM) or /mingw/.match(RUBY_PLATFORM)
-  
+
   require 'fiddle/import'
   require 'fiddle/types'
   module WinAPI
@@ -45,9 +45,9 @@ if /mswin/.match(RUBY_PLATFORM) or /mingw/.match(RUBY_PLATFORM)
   end
 
   buffer = 1024
-  original_dll_directory = Fiddle::Pointer.malloc(buffer) 
+  original_dll_directory = Fiddle::Pointer.malloc(buffer)
   WinAPI.GetDllDirectory(buffer, original_dll_directory)
-  
+
   qt_dll_path = File.expand_path(File.join(File.dirname(__FILE__), '../bin/'))
   WinAPI.SetDllDirectory(qt_dll_path)
 
@@ -57,28 +57,36 @@ else
   # Do something here for Mac OSX environments
   qt_so_path = File.expand_path(File.join(File.dirname(__FILE__), '../bin/'))
   ENV['PATH'] = "#{qt_so_path}:#{original_path}"
-  
+
   $OPENSTUDIO_APPLICATION_DIR = File.join(File.dirname(__FILE__), '../bin/')
 end
 
 begin
 
   # require openstudio
-  require_relative 'openstudio'
+  begin
+    require_relative 'openstudio'
+  rescue LoadError
+    begin
+      require 'openstudio'
+    rescue LoadError
+      puts 'Unable to require openstudio'
+    end
+  end
 
   # require openstudio_modeleditor.so
   require_relative 'openstudio_modeleditor.so'
-  
+
   # add this directory to Ruby load path
   $:.unshift(File.expand_path(File.dirname(__FILE__)))
-  
+
 ensure
 
   # restore original path
   ENV['PATH'] = original_path
-  
+
   if original_dll_directory
     WinAPI.SetDllDirectory(original_dll_directory)
   end
-  
+
 end

--- a/ruby/test/PathWatcher_Test.rb
+++ b/ruby/test/PathWatcher_Test.rb
@@ -28,10 +28,11 @@
 ########################################################################################################################
 
 require 'openstudio'
+require 'openstudio_modeleditor'
 
 require 'minitest/autorun'
 
-class TestPathWatcher < OpenStudio::PathWatcher
+class TestPathWatcher < OpenStudio::Modeleditor::PathWatcher
 
   attr_accessor :changed
 
@@ -57,7 +58,7 @@ end
 class PathWatcher_Test < MiniTest::Unit::TestCase
 
   def setup
-    OpenStudio::Application::instance().application(false)
+    OpenStudio::Modeleditor::Application::instance().application(false)
   end
 
   # def teardown
@@ -95,7 +96,7 @@ class PathWatcher_Test < MiniTest::Unit::TestCase
 
     # calls processEvents
     OpenStudio::System::msleep(10000)
-    OpenStudio::Application::instance().processEvents(10000)
+    OpenStudio::Modeleditor::Application::instance().processEvents(10000)
 
     assert(watcher.changed)
     watcher.changed = false
@@ -106,7 +107,7 @@ class PathWatcher_Test < MiniTest::Unit::TestCase
 
     # calls processEvents
     OpenStudio::System::msleep(10000)
-    OpenStudio::Application::instance().processEvents(10000)
+    OpenStudio::Modeleditor::Application::instance().processEvents(10000)
 
     assert(watcher.changed)
   end
@@ -137,7 +138,7 @@ class PathWatcher_Test < MiniTest::Unit::TestCase
 
     # calls processEvents
     OpenStudio::System::msleep(10000)
-    OpenStudio::Application::instance().processEvents(10000)
+    OpenStudio::Modeleditor::Application::instance().processEvents(10000)
 
     assert(watcher.changed)
     watcher.changed = false
@@ -148,7 +149,7 @@ class PathWatcher_Test < MiniTest::Unit::TestCase
 
     # calls processEvents
     OpenStudio::System::msleep(10000)
-    OpenStudio::Application::instance().processEvents(10000)
+    OpenStudio::Modeleditor::Application::instance().processEvents(10000)
 
     assert(watcher.changed)
 

--- a/ruby/test/PathWatcher_Test.rb
+++ b/ruby/test/PathWatcher_Test.rb
@@ -1,0 +1,161 @@
+########################################################################################################################
+#  OpenStudio(R), Copyright (c) 2008-2019, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+#  following conditions are met:
+#
+#  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+#  disclaimer.
+#
+#  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+#  disclaimer in the documentation and/or other materials provided with the distribution.
+#
+#  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+#  derived from this software without specific prior written permission from the respective party.
+#
+#  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+#  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+#  written permission from Alliance for Sustainable Energy, LLC.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+#  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+#  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+#  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+########################################################################################################################
+
+require 'openstudio'
+
+require 'minitest/autorun'
+
+class TestPathWatcher < OpenStudio::PathWatcher
+
+  attr_accessor :changed
+
+  def initialize(path)
+    super
+    @changed = false
+  end
+
+  def onPathChanged
+	#puts 'onPathChanged'
+	#STDOUT.flush
+    @changed = true
+  end
+
+  def onPathRemoved
+	#puts 'onPathRemoved'
+	#STDOUT.flush
+    @changed = true
+  end
+
+end
+
+class PathWatcher_Test < MiniTest::Unit::TestCase
+
+  def setup
+    OpenStudio::Application::instance().application(false)
+  end
+
+  # def teardown
+  # end
+
+  def test_watchFile
+    p = OpenStudio::Path.new("./path_watcher_file")
+    if OpenStudio::exists(p)
+      OpenStudio::remove(p)
+    end
+    assert((not OpenStudio::exists(p)))
+
+    File.open(p.to_s, 'w') do |f|
+      f << "test 1"
+	  begin
+	    f.fsync
+	  rescue
+	    f.flush
+	  end
+    end
+    assert(OpenStudio::exists(p))
+
+    watcher = TestPathWatcher.new(p)
+    assert((not watcher.changed))
+
+    # write to the file
+    File.open(p.to_s, 'w') do |f|
+      f << "test 2"
+	  begin
+	    f.fsync
+	  rescue
+	    f.flush
+	  end
+    end
+
+    # calls processEvents
+    OpenStudio::System::msleep(10000)
+    OpenStudio::Application::instance().processEvents(10000)
+
+    assert(watcher.changed)
+    watcher.changed = false
+    assert((not watcher.changed))
+
+    OpenStudio::remove(p)
+    assert((not OpenStudio::exists(p)))
+
+    # calls processEvents
+    OpenStudio::System::msleep(10000)
+    OpenStudio::Application::instance().processEvents(10000)
+
+    assert(watcher.changed)
+  end
+
+  def test_watchDir
+    p = OpenStudio::Path.new("./")
+    assert(OpenStudio::exists(p))
+
+    filePath = OpenStudio::Path.new("./path_watcher_dir")
+    if OpenStudio::exists(filePath)
+      OpenStudio::remove(filePath)
+    end
+    assert((not OpenStudio::exists(filePath)))
+
+    watcher = TestPathWatcher.new(p)
+    assert((not watcher.changed))
+
+    filePath = OpenStudio::Path.new("./path_watcher_dir")
+    File.open(filePath.to_s, 'w') do |f|
+      f << "test 1"
+	  begin
+		f.fsync
+	  rescue
+	    f.flush
+	  end
+    end
+    assert(OpenStudio::exists(filePath))
+
+    # calls processEvents
+    OpenStudio::System::msleep(10000)
+    OpenStudio::Application::instance().processEvents(10000)
+
+    assert(watcher.changed)
+    watcher.changed = false
+    assert((not watcher.changed))
+
+    OpenStudio::remove(filePath)
+    assert((not OpenStudio::exists(filePath)))
+
+    # calls processEvents
+    OpenStudio::System::msleep(10000)
+    OpenStudio::Application::instance().processEvents(10000)
+
+    assert(watcher.changed)
+
+    # try non-existent dir
+    assert_raises(RuntimeError){TestPathWatcher.new(OpenStudio::Path.new("./I do not exist/"))}
+  end
+
+end
+
+

--- a/ruby/test/WorkspaceWatcher_Test.rb
+++ b/ruby/test/WorkspaceWatcher_Test.rb
@@ -28,6 +28,7 @@
 ########################################################################################################################
 
 require 'openstudio'
+require 'openstudio_modeleditor'
 
 require 'minitest/autorun'
 
@@ -108,7 +109,7 @@ class WorkspaceWatcher_Test < MiniTest::Unit::TestCase
     assert(watcher.dirty)
     assert(watcher.objectAdded)
     assert(watcher.enabled)
-    OpenStudio::Application::instance.processEvents
+    OpenStudio::Modeleditor::Application::instance.processEvents
     assert(watcher.addedObjectHandle)
     assert((not watcher.removedObjectHandle))
     assert_equal(addedObjectHandle.to_s, watcher.addedObjectHandle.to_s)

--- a/ruby/test/WorkspaceWatcher_Test.rb
+++ b/ruby/test/WorkspaceWatcher_Test.rb
@@ -1,0 +1,134 @@
+########################################################################################################################
+#  OpenStudio(R), Copyright (c) 2008-2019, Alliance for Sustainable Energy, LLC, and other contributors. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+#  following conditions are met:
+#
+#  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+#  disclaimer.
+#
+#  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+#  disclaimer in the documentation and/or other materials provided with the distribution.
+#
+#  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+#  derived from this software without specific prior written permission from the respective party.
+#
+#  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+#  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+#  written permission from Alliance for Sustainable Energy, LLC.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+#  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+#  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+#  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+#  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+#  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+########################################################################################################################
+
+require 'openstudio'
+
+require 'minitest/autorun'
+
+module OpenStudio
+
+  class TestWorkspaceWatcher < WorkspaceWatcher
+
+    attr_accessor :addedObjectHandle, :removedObjectHandle
+
+    def initialize(workspace)
+      @addedObjectHandle = nil
+      @removedObjectHandle = nil
+      super
+    end
+
+    def clearState
+      super
+      @addedObjectHandle = nil
+      @removedObjectHandle = nil
+      puts "clearState"
+    end
+
+    def onChangeWorkspace
+      super
+      puts "onChangeWorkspace"
+    end
+
+    def onBecomeDirty
+      super
+      puts "onBecomeDirty"
+    end
+
+    def onBecomeClean
+      super
+      puts "onBecomeClean"
+    end
+
+    def onObjectAdd(addedObject)
+      super
+      @addedObjectHandle = addedObject.handle
+      puts "onObjectAdd"
+    end
+
+    def onObjectRemove(removedObject)
+      super
+      @removedObjectHandle = removedObject.handle
+      puts "removedObject"
+    end
+
+  end
+
+end
+
+
+class WorkspaceWatcher_Test < MiniTest::Unit::TestCase
+
+  # def setup
+  # end
+
+  # def teardown
+  # end
+
+  def test_WorkspaceWatcher
+
+    workspace = OpenStudio::Workspace.new
+    watcher = OpenStudio::TestWorkspaceWatcher.new(workspace)
+
+    assert((not watcher.dirty))
+    assert((not watcher.addedObjectHandle))
+    assert((not watcher.removedObjectHandle))
+
+    idfObject = OpenStudio::IdfObject.new("OS_Space".to_IddObjectType)
+    addedObject = workspace.addObject(idfObject)
+    assert((not addedObject.empty?))
+    addedObjectHandle = addedObject.get.handle
+
+    assert_equal(1, workspace.numObjects)
+    assert(watcher.dirty)
+    assert(watcher.objectAdded)
+    assert(watcher.enabled)
+    OpenStudio::Application::instance.processEvents
+    assert(watcher.addedObjectHandle)
+    assert((not watcher.removedObjectHandle))
+    assert_equal(addedObjectHandle.to_s, watcher.addedObjectHandle.to_s)
+
+    watcher.clearState
+
+    assert((not watcher.dirty))
+    assert((not watcher.addedObjectHandle))
+    assert((not watcher.removedObjectHandle))
+
+    addedObject.get.remove
+
+    assert_equal(0, workspace.numObjects)
+    assert(watcher.dirty)
+    assert((not watcher.addedObjectHandle))
+    assert(watcher.removedObjectHandle)
+    assert_equal(addedObjectHandle.to_s, watcher.removedObjectHandle.to_s)
+
+  end
+
+end
+
+

--- a/ruby/test/WorkspaceWatcher_Test.rb
+++ b/ruby/test/WorkspaceWatcher_Test.rb
@@ -85,8 +85,9 @@ end
 
 class WorkspaceWatcher_Test < MiniTest::Unit::TestCase
 
-  # def setup
-  # end
+  def setup
+    OpenStudio::Modeleditor::Application::instance().application(false)
+  end
 
   # def teardown
   # end

--- a/src/model_editor/ModelEditor.i
+++ b/src/model_editor/ModelEditor.i
@@ -27,7 +27,6 @@
   #include <model_editor/InspectorDialog.hpp>
   #include <model_editor/ModalDialogs.hpp>
   #include <model_editor/OSProgressBar.hpp>
-  #include <model_editor/PathWatcher.hpp>
   #include <model_editor/Utilities.hpp>
 
   #include <openstudio/model/Model.hpp>
@@ -51,6 +50,13 @@
     class WorkspaceObjectWatcher;
     class WorkspaceWatcher;
   }
+%}
+
+#if defined(SWIGCSHARP) || defined(SWIGJAVA)
+%module(directors="1")
+#endif
+%{
+  #include <model_editor/PathWatcher.hpp>
 %}
 
 %include <model_editor/Qt.i>

--- a/src/model_editor/PathWatcher.hpp
+++ b/src/model_editor/PathWatcher.hpp
@@ -30,6 +30,8 @@
 #ifndef MODELEDITOR_PATHWATCHER_HPP
 #define MODELEDITOR_PATHWATCHER_HPP
 
+#include "ModelEditorAPI.hpp"
+
 #include <openstudio/utilities/core/Path.hpp>
 
 #include <QObject>
@@ -42,7 +44,7 @@ class QTimer;
 /** Class for watching either a file or directory, QFileSystemWatcher has issues when watching
   **  many files so it is not recommended to use too many of these objects.
   **/
-class PathWatcher : public QObject
+class MODELEDITOR_API PathWatcher : public QObject
 {
 
   Q_OBJECT;

--- a/src/model_editor/test/PathWatcher_GTest.cpp
+++ b/src/model_editor/test/PathWatcher_GTest.cpp
@@ -102,6 +102,7 @@ TEST_F(ModelEditorFixture, PathWatcher_File) {
 
   EXPECT_TRUE(openstudio::filesystem::exists(path));
 
+  openstudio::System::msleep(1000);
   Application::instance().processEvents(10);
 
   EXPECT_FALSE(watcher.added);
@@ -115,6 +116,7 @@ TEST_F(ModelEditorFixture, PathWatcher_File) {
 
   EXPECT_FALSE(openstudio::filesystem::exists(path));
 
+  openstudio::System::msleep(1000);
   Application::instance().processEvents(10);
 
   EXPECT_FALSE(watcher.added);
@@ -145,6 +147,7 @@ TEST_F(ModelEditorFixture, PathWatcher_Dir) {
 
   EXPECT_TRUE(openstudio::filesystem::exists(filePath));
 
+  openstudio::System::msleep(1000);
   Application::instance().processEvents(10);
 
   EXPECT_TRUE(watcher.changed);
@@ -157,6 +160,7 @@ TEST_F(ModelEditorFixture, PathWatcher_Dir) {
 
   EXPECT_TRUE(openstudio::filesystem::exists(filePath));
 
+  openstudio::System::msleep(1000);
   Application::instance().processEvents(10);
 
   EXPECT_FALSE(watcher.changed);
@@ -167,6 +171,7 @@ TEST_F(ModelEditorFixture, PathWatcher_Dir) {
 
   EXPECT_FALSE(openstudio::filesystem::exists(filePath));
 
+  openstudio::System::msleep(1000);
   Application::instance().processEvents(10);
 
   EXPECT_TRUE(watcher.changed);


### PR DESCRIPTION
Companion PR to develop3 where I basically deleted these two tests: https://github.com/NREL/OpenStudio/pull/3808

The tests still don't work though

```
$ ctest -VV -R OSApp-RubyTest-PathWatcher_Test-watchFile

tart 2754: OSApp-RubyTest-PathWatcher_Test-watchFile

2754: Test command: /usr/local/bin/cmake "-E" "chdir" "/home/julien/Software/Others/OSApp-build/ruby" "/home/julien/.rvm/rubies/ruby-2.5.5/bin/ruby" "-I" "/home/julien/Software/Others/OSApp-build/openstudio/Products/ruby" "/home/julien/Software/Others/OpenStudioApplication/ruby/test/PathWatcher_Test.rb" "--name=test_watchFile"
2754: Test timeout computed to be: 660
2754: /home/julien/Software/Others/OpenStudioApplication/ruby/test/PathWatcher_Test.rb:34:in `<main>': uninitialized constant OpenStudio::PathWatcher (NameError)
1/1 Test #2754: OSApp-RubyTest-PathWatcher_Test-watchFile ...***Failed    0.43 sec
```

If I keep the location of the openstudio_modeleditor.so (and rb) to the current (that is Products/ruby and not openstudio/Products/ruby like the openstudio.so)

```
irb -I /home/julien/Software/Others/OSApp-build/Products/ruby/
2.5.5 :001 > require 'openstudio_modeleditor'
Traceback (most recent call last):
       10: from /home/julien/.rvm/gems/ruby-2.5.5/bin/ruby_executable_hooks:24:in `<main>'
        9: from /home/julien/.rvm/gems/ruby-2.5.5/bin/ruby_executable_hooks:24:in `eval'
        8: from /home/julien/.rvm/gems/ruby-2.5.5/bin/irb:23:in `<main>'
        7: from /home/julien/.rvm/gems/ruby-2.5.5/bin/irb:23:in `load'
        6: from /home/julien/.rvm/gems/ruby-2.5.5/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        5: from (irb):1
        4: from /home/julien/.rvm/rubies/ruby-2.5.5/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        3: from /home/julien/.rvm/rubies/ruby-2.5.5/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        2: from /home/julien/Software/Others/OSApp-build/Products/ruby/openstudio_modeleditor.rb:64:in `<top (required)>'
        1: from /home/julien/Software/Others/OSApp-build/Products/ruby/openstudio_modeleditor.rb:64:in `require_relative'
LoadError (cannot load such file -- /home/julien/Software/Others/OSApp-build/Products/ruby/openstudio)
```


I tried to output the openstudio_modeleditor.so (and rb) directly to <build>/openstudio/Products/ruby` so that it sits next to the openstudio.so. PathWatcher still isn't recognized, and I get a weird message when I exit.


```
$ irb -I /home/julien/Software/Others/OSApp-build/openstudio/Products/ruby
2.5.5 :001 > require 'openstudio_modeleditor'
 => true 
2.5.5 :002 > OpenStudio::Model::Model.new
 => #<OpenStudio::Model::Model:0x00005643eefd2c48 @__swigtype__="_p_openstudio__model__Model"> 
2.5.5 :003 > OpenStudio::PatchWatcher
Traceback (most recent call last):
        6: from /home/julien/.rvm/gems/ruby-2.5.5/bin/ruby_executable_hooks:24:in `<main>'
        5: from /home/julien/.rvm/gems/ruby-2.5.5/bin/ruby_executable_hooks:24:in `eval'
        4: from /home/julien/.rvm/gems/ruby-2.5.5/bin/irb:23:in `<main>'
        3: from /home/julien/.rvm/gems/ruby-2.5.5/bin/irb:23:in `load'
        2: from /home/julien/.rvm/gems/ruby-2.5.5/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        1: from (irb):4
NameError (uninitialized constant OpenStudio::PatchWatcher)
2.5.5 :004 > exit
double free or corruption (!prev)
Aborted (core dumped)
```