### PR TITLE
Fix #106 - OpenStudioPolicy.xml couldn't be loaded correctly due to deprecated IDD object

### DIFF
--- a/src/model_editor/AccessPolicyStore.cpp
+++ b/src/model_editor/AccessPolicyStore.cpp
@@ -32,6 +32,9 @@
 
 #include <QXmlDefaultHandler>
 #include <QXmlReader>
+#include <QXmlSimpleReader>
+#include <QXmlInputSource>
+#include <QXmlAttributes>
 
 #include "AccessPolicyStore.hpp"
 

--- a/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0"?>
-<!-- edited with XMLSpy v2008 (http://www.altova.com) by Daniel Macumber (NREL) -->
 <ROOT>
   <POLICY IddObjectType="OS_AirLoopHVAC_SupplyPlenum">
     <rule IddField="Thermal Zone" Access="LOCKED"/>
@@ -764,11 +763,6 @@
     <rule IddField="Availability Schedule Name" Access="HIDDEN"/>
     <rule IddField="Air Inlet Node Name" Access="HIDDEN"/>
     <rule IddField="Air Outlet Node Name" Access="HIDDEN"/>
-  </POLICY>
-  <POLICY IddObjectType="OS_AirTerminal_SingleDuct_Uncontrolled">
-    <rule IddField="Availability Schedule Name" Access="HIDDEN"/>
-    <rule IddField="Inlet Air Node Name" Access="HIDDEN"/>
-    <rule IddField="Zone Supply Air Node Name" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_AirTerminal_SingleDuct_ParallelPIU_Reheat">
     <rule IddField="Availability Schedule Name" Access="HIDDEN"/>

--- a/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -1230,7 +1230,7 @@
     <rule IddField="Nominal Floor to Ceiling Height" Access="LOCKED"/>
   </POLICY>
   <POLICY IddObjectType="OS_DefaultConstructionSet">
-    <rule IddField="Name" Access="LOCKED"/>
+    <!--<rule IddField="Name" Access="LOCKED"/>-->
     <rule IddField="Default Exterior Surface Constructions Name" Access="LOCKED"/>
     <rule IddField="Default Interior Surface Constructions Name" Access="LOCKED"/>
     <rule IddField="Default Ground Contact Surface Constructions Name" Access="LOCKED"/>
@@ -1242,7 +1242,7 @@
     <rule IddField="Site Shading Construction Name" Access="LOCKED"/>
   </POLICY>
   <POLICY IddObjectType="OS_DefaultScheduleSet">
-    <rule IddField="Name" Access="LOCKED"/>
+    <!--<rule IddField="Name" Access="LOCKED"/>-->
     <rule IddField="Hours of Operation Schedule Name" Access="LOCKED"/>
     <rule IddField="Number of People Schedule Name" Access="LOCKED"/>
     <rule IddField="People Activity Level Schedule Name" Access="LOCKED"/>


### PR DESCRIPTION
Fix #106 - Remove `OS_AirTerminal_SingleDuct_Uncontrolled` from `OpenStudioPolicy.xml`

-----

Optionally: Fix #102 - Allow editing the DefaultConstructionSet and DefaultScheduleSet names from the inspector gadget

I'm not sure whether we do want to allow that or not, it seems to be in contradiction with pretty much all other objects. I see the value in being able to, and can't think of any drawbacks, but I may be missing something. @kyle @tijcolem?

Other objects include Space Type (can't change its name when on Space's tab), BuildingStory, etc.