### PR TITLE
Fix linking error in openstudio_lib_tests

### DIFF
--- a/src/openstudio_lib/CMakeLists.txt
+++ b/src/openstudio_lib/CMakeLists.txt
@@ -716,7 +716,7 @@ add_library(${target_name}
   ${${target_name}_qrcs}
 )
 
-set(depends
+set(${target_name}_depends
   openstudio_modeleditor
   openstudio::openstudiolib
   ${QT_LIBS}
@@ -725,7 +725,7 @@ if(WIN32)
   list(APPEND ${target_name}_depends qtwinmigrate)
 endif()
 
-target_link_libraries(${target_name} ${depends})
+target_link_libraries(${target_name} ${${target_name}_depends})
 
 AddPCH(${target_name})
 


### PR DESCRIPTION
Getting a link error in openstudio_lib_tests:

```
[ 95%][544/570] Linking CXX executable Products/openstudio_lib_tests-1.0.0
FAILED: Products/openstudio_lib_tests-1.0.0 
: && /usr/bin/c++  -fdiagnostics-color=always  -fPIC -fno-strict-aliasing -Winvalid-pch -Wno-overloaded-virtual -Wno-maybe-uninitialized -std=c++17 -O3 -DNDEBUG   src/openstudio_lib/CMakeFiles/openstudio_lib_tests.dir/test/OpenStudioLibFixture.cpp.o src/openstudio_lib/CMakeFiles/openstudio_lib_tests.dir/test/IconLibrary_GTest.cpp.o  -o Products/openstudio_lib_tests-1.0.0  -Wl,-rpath,/home/julien/Software/Others/OS-build-release/_CPack_Packages/Linux/TGZ/OpenStudio-3.0.1-beta+a5804b8c0a-Linux/usr/local/openstudio-3.0.1-beta/lib:/home/julien/Software/Others/OSApp-build-release/Qt-install/lib  Products/libopenstudio_lib.a  /home/julien/.conan/data/gtest/1.10.0/_/_/package/a4062ec0208a59375ac653551e662b6cc469fe58/lib/libgmock_main.a  /home/julien/.conan/data/gtest/1.10.0/_/_/package/a4062ec0208a59375ac653551e662b6cc469fe58/lib/libgmock.a  /home/julien/.conan/data/gtest/1.10.0/_/_/package/a4062ec0208a59375ac653551e662b6cc469fe58/lib/libgtest.a  Products/libopenstudio_modeleditor.a  /home/julien/Software/Others/OS-build-release/_CPack_Packages/Linux/TGZ/OpenStudio-3.0.1-beta+a5804b8c0a-Linux/usr/local/openstudio-3.0.1-beta/lib/libopenstudiolib.so  /home/julien/.conan/data/jsoncpp/1.9.2/_/_/package/66c5327ebdcecae0a01a863939964495fa019a06/lib/libjsoncpp.a  /home/julien/.conan/data/cpprestsdk/2.10.14/bincrafters/stable/package/0cec7e5950a998ac0578489464841ccf33a4f5fe/lib/libcpprest.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_wave.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_container.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_contract.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_exception.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_graph.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_iostreams.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_locale.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_log.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_program_options.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_random.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_regex.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_serialization.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_wserialization.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_coroutine.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_fiber.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_context.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_timer.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_thread.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_chrono.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_date_time.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_atomic.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_filesystem.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_system.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_type_erasure.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_log_setup.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_math_c99.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_math_c99f.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_math_c99l.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_math_tr1.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_math_tr1f.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_math_tr1l.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_stacktrace_addr2line.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_stacktrace_backtrace.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_stacktrace_basic.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_stacktrace_noop.a  /home/julien/.conan/data/boost/1.71.0/_/_/package/84aa75c7e2b2b3d1cb01af39298d01342cf8d782/lib/libboost_unit_test_framework.a  -lrt  /home/julien/.conan/data/bzip2/1.0.8/_/_/package/b27e2b40bcb70be2e7d6f0e0c6e43e35c530f8d3/lib/libbz2.a  /home/julien/.conan/data/zlib/1.2.11/_/_/package/aff0eb9e4c299cac0972a5fe39033141b3e50a6d/lib/libminizip.a  /home/julien/.conan/data/zlib/1.2.11/_/_/package/aff0eb9e4c299cac0972a5fe39033141b3e50a6d/lib/libz.a  /home/julien/.conan/data/openssl/1.1.0l/_/_/package/d50a0d523d98c15bb147b18fa7d203887c38be8b/lib/libssl.a  /home/julien/.conan/data/openssl/1.1.0l/_/_/package/d50a0d523d98c15bb147b18fa7d203887c38be8b/lib/libcrypto.a  -ldl  -lpthread  /home/julien/.conan/data/pugixml/1.10/bincrafters/stable/package/66c5327ebdcecae0a01a863939964495fa019a06/lib/libpugixml.a  Qt-install/lib/libQt5Network.so.5.11.2  Qt-install/lib/libQt5Xml.so.5.11.2  Qt-install/lib/libQt5Concurrent.so.5.11.2  Qt-install/lib/libQt5PrintSupport.so.5.11.2  Qt-install/lib/libQt5Widgets.so.5.11.2  Qt-install/lib/libQt5Core.so.5.11.2  Qt-install/lib/libQt5Gui.so.5.11.2 && :
ld: error: undefined symbol: QWebEngineView::load(QUrl const&)
>>> referenced by ResultsTabView.cpp
>>>               ResultsTabView.cpp.o:(openstudio::ResultsView::comboBoxChanged(int)) in archive Products/libopenstudio_lib.a
>>> referenced by GeometryEditorView.cpp
>>>               GeometryEditorView.cpp.o:(openstudio::DebugWebView::DebugWebView(QString const&, QWidget*)) in archive Products/libopenstudio_lib.a
>>> referenced by GeometryEditorView.cpp
>>>               GeometryEditorView.cpp.o:(openstudio::GbXmlEditor::GbXmlEditor(boost::filesystem::path const&, bool, openstudio::model::Model const&, QWebEngineView*, QWidget*)) in archive Products/libopenstudio_lib.a
>>> referenced 7 more times
ld: error: undefined symbol: QWebEngineView::title() const
>>> referenced by ResultsTabView.cpp
>>>               ResultsTabView.cpp.o:(openstudio::ResultsView::onLoadFinished(bool)) in archive Products/libopenstudio_lib.a
>>> referenced by GeometryEditorView.cpp
>>>               GeometryEditorView.cpp.o:(openstudio::EditorWebView::onLoadFinished(bool)) in archive Products/libopenstudio_lib.a
>>> referenced by GeometryPreviewView.cpp
>>>               GeometryPrev

[... more ...]
```