### PR TITLE
Fixes crash on save when model directory is open in Explorer on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ build_profile/
 build-profile/
 core-build/
 super-build/
+debug/
+release/
 /super-build-shared/
 /super-build-static/
 

--- a/src/openstudio_lib/OSDocument.cpp
+++ b/src/openstudio_lib/OSDocument.cpp
@@ -1379,7 +1379,9 @@ bool OSDocument::save() {
     // saves the model to modelTempDir / m_savePath.filename()
     // also copies the temp files to user location
     bool saved = saveModel(this->model(), modelPath, toPath(m_modelTempDir));
-    OS_ASSERT(saved);
+    if (!saved) {
+      QMessageBox::warning(this->mainWindow(), tr("Failed to save model"), tr("Failed to save model, make sure that you do not have the location open and that you have correct write access."));
+    }
 
     this->setSavePath(toQString(modelPath));
 

--- a/src/openstudio_lib/OSDocument.cpp
+++ b/src/openstudio_lib/OSDocument.cpp
@@ -1380,7 +1380,8 @@ bool OSDocument::save() {
     // also copies the temp files to user location
     bool saved = saveModel(this->model(), modelPath, toPath(m_modelTempDir));
     if (!saved) {
-      QMessageBox::warning(this->mainWindow(), tr("Failed to save model"), tr("Failed to save model, make sure that you do not have the location open and that you have correct write access."));
+      QMessageBox::warning(this->mainWindow(), tr("Failed to save model"),
+                           tr("Failed to save model, make sure that you do not have the location open and that you have correct write access."));
     }
 
     this->setSavePath(toQString(modelPath));


### PR DESCRIPTION
Fixes #177

Depends on NREL/OpenStudio#4026

We should decide if we want to fork OpenStudio to get this change in the app earlier, if we want to wait for NREL to make a release with it, or something else