### PR TITLE
#202 OutputDiagnostics and OuputTableSummaryReports

### DIFF
--- a/src/openstudio_lib/SimSettingsView.cpp
+++ b/src/openstudio_lib/SimSettingsView.cpp
@@ -1882,10 +1882,7 @@ void SimSettingsView::attachOutputTableSummaryReports() {
   }
 
   // typedef std::function<bool()> BoolGetter
-  std::function<bool()> getter = [this]() {
-    return m_outputTableSummaryReports->summaryReportIndex("AllSummary").has_value();
-  };
-
+  std::function<bool()> getter = [this]() { return m_outputTableSummaryReports->summaryReportIndex("AllSummary").has_value(); };
 
   // typedef std::function<void(bool)> BoolSetter;
   std::function<void(bool)> setter = [this](bool value) {
@@ -1911,16 +1908,11 @@ void SimSettingsView::attachOutputDiagnostics() {
   // typedef std::function<bool()> BoolGetter
   std::function<bool()> getter = [this]() {
     auto ks = m_outputDiagnostics->keys();
-    return std::find_if(ks.begin(), ks.end(),
-                        [](const std::string& k) {
-                          return openstudio::istringEqual(k, "DisplayExtraWarnings");
-                        }
-                       ) != ks.end();
+    return std::find_if(ks.begin(), ks.end(), [](const std::string& k) { return openstudio::istringEqual(k, "DisplayExtraWarnings"); }) != ks.end();
   };
 
   // void bind(const model::ModelObject& modelObject, BoolGetter get, boost::optional<BoolSetter> set = boost::none,
   //           boost::optional<NoFailAction> reset = boost::none, boost::optional<BasicQuery> isDefaulted = boost::none);
-
 
   // typedef std::function<void(bool)> BoolSetter;
   std::function<void(bool)> setter = [this](bool value) {
@@ -1928,18 +1920,15 @@ void SimSettingsView::attachOutputDiagnostics() {
       m_outputDiagnostics->enableDisplayExtraWarnings();
     } else {
       auto ks = m_outputDiagnostics->keys();
-      ks.erase(std::remove_if(ks.begin(), ks.end(),
-                              [](const std::string& k) {
-                                return openstudio::istringEqual(k, "DisplayExtraWarnings");
-                              }),
+      ks.erase(std::remove_if(ks.begin(), ks.end(), [](const std::string& k) { return openstudio::istringEqual(k, "DisplayExtraWarnings"); }),
                ks.end());
       m_outputDiagnostics->setKeys(ks);
     }
   };
 
   m_diagnostics_displayExtraWarnings->bind(*m_outputDiagnostics, getter, setter,
-                           boost::none,  // reset
-                           boost::none   // isDefaulted;
+                                           boost::none,  // reset
+                                           boost::none   // isDefaulted;
   );
 }
 

--- a/src/openstudio_lib/SimSettingsView.hpp
+++ b/src/openstudio_lib/SimSettingsView.hpp
@@ -89,6 +89,8 @@ class SimSettingsView : public QWidget, public Nano::Observer
   QWidget* createZoneCapacitanceMultipleResearchSpecialWidget();
   QWidget* createRadianceParametersWidget();
   QWidget* createOutputJSONWidget();
+  QWidget* createOutputTableSummaryReportsWidget();
+  QWidget* createOutputDiagnosticsWidget();
 
   void addField(QGridLayout* gridLayout, int row, int column, QString text, OSComboBox2*& comboBox);
 
@@ -126,6 +128,8 @@ class SimSettingsView : public QWidget, public Nano::Observer
   void attachZoneCapacitanceMultipleResearchSpecial();
   void attachRadianceParameters();
   void attachOutputJSON();
+  void attachOutputTableSummaryReports();
+  void attachOutputDiagnostics();
 
   void detachAll();
   void detachRunPeriod();
@@ -145,6 +149,8 @@ class SimSettingsView : public QWidget, public Nano::Observer
   void detachZoneCapacitanceMultipleResearchSpecial();
   void detachRadianceParameters();
   void detachOutputJSON();
+  void detachOutputTableSummaryReports();
+  void detachOutputDiagnostics();
 
   model::Model m_model;
   boost::optional<model::ShadowCalculation> m_shadowCalculation;
@@ -278,6 +284,11 @@ class SimSettingsView : public QWidget, public Nano::Observer
   OSSwitch2* m_json_outputJSON;
   OSSwitch2* m_json_outputCBOR;
   OSSwitch2* m_json_outputMessagePack;
+
+  // Advanced Output
+  // These are extensible groups in the SDK, but we care only about common settings
+  OSSwitch2* m_table_allSummary;
+  OSSwitch2* m_diagnostics_displayExtraWarnings;
 
  signals:
 

--- a/src/openstudio_lib/SimSettingsView.hpp
+++ b/src/openstudio_lib/SimSettingsView.hpp
@@ -36,6 +36,8 @@
 #include <openstudio/model/Model.hpp>
 #include <openstudio/model/ShadowCalculation.hpp>
 #include <openstudio/model/SimulationControl.hpp>
+#include <openstudio/model/OutputTableSummaryReports.hpp>
+#include <openstudio/model/OutputDiagnostics.hpp>
 #include <openstudio/model/RunPeriod.hpp>
 
 class QButtonGroup;
@@ -155,6 +157,8 @@ class SimSettingsView : public QWidget, public Nano::Observer
   model::Model m_model;
   boost::optional<model::ShadowCalculation> m_shadowCalculation;
   boost::optional<model::SimulationControl> m_simulationControl;
+  boost::optional<model::OutputTableSummaryReports> m_outputTableSummaryReports;
+  boost::optional<model::OutputDiagnostics> m_outputDiagnostics;
 
   QCheckBox* m_runSimWeatherFiles;
   QCheckBox* m_runSimDesignDays;


### PR DESCRIPTION
This impements only the most common field:

Fix #202 - OutputDiagnostics => toggle DisplayExtraWarnings
Fix #319 - OuputTableSummaryReports => toggle AllSummaryReports

In the OS SDK, if no model object OuputTableSummaryReports is present, then in the ForwardTranslator, the AllSummary is added. So I reproduce this behavior here.

![202_OutputDiagnostics_OutputTableSummaryReports](https://user-images.githubusercontent.com/5479063/107530369-16793d00-6bbc-11eb-8c7b-e59e6ab1b103.gif)


