### PR TITLE
Add environment variable to control which tab is shown on startup - Supported by Ladybug Tools

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Run cppcheck
       shell: bash
       run: |
+          snap list cppcheck
           sudo snap install cppcheck
           cppcheck \
             --suppress=noExplicitConstructor \

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -15,8 +15,8 @@ jobs:
     - name: Run cppcheck
       shell: bash
       run: |
-          snap list cppcheck
-          sudo snap install cppcheck
+          # Current stable (2.3-25-20201207-23616-ga9f4a14c8, rev 1637) is broken, so use edge for now
+          sudo snap install cppcheck --edge
           cppcheck \
             --suppress=noExplicitConstructor \
             --suppress=useStlAlgorithm \

--- a/src/model_editor/InspectorDialog.cpp
+++ b/src/model_editor/InspectorDialog.cpp
@@ -271,7 +271,7 @@ openstudio::model::Model InspectorDialog::model() const {
   return m_model;
 }
 
-void InspectorDialog::setModel(openstudio::model::Model& model, bool force) {
+void InspectorDialog::setModel(const openstudio::model::Model& model, bool force) {
   if ((model == m_model) && !force) {
     return;
   }

--- a/src/model_editor/InspectorDialog.hpp
+++ b/src/model_editor/InspectorDialog.hpp
@@ -95,7 +95,7 @@ class MODELEDITOR_API InspectorDialog : public QMainWindow, public Nano::Observe
   openstudio::model::Model model() const;
 
   // point the dialog at a new model
-  void setModel(openstudio::model::Model& model, bool force = false);
+  void setModel(const openstudio::model::Model& model, bool force = false);
 
   // void rebuild inspector gadget
   void rebuildInspectorGadget(bool recursive);

--- a/src/model_editor/InspectorGadget.cpp
+++ b/src/model_editor/InspectorGadget.cpp
@@ -771,8 +771,8 @@ void InspectorGadget::layoutComboBox(QVBoxLayout* layout, QWidget* parent, opens
       combo->addItem("");
     }
 
-    for (const std::string& name : names) {
-      combo->addItem(name.c_str());
+    for (const std::string& thisName : names) {
+      combo->addItem(thisName.c_str());
     }
   } else {
     if (!prop.required) {

--- a/src/model_editor/InspectorGadget.hpp
+++ b/src/model_editor/InspectorGadget.hpp
@@ -155,7 +155,7 @@ class MODELEDITOR_API InspectorGadget : public QWidget, public Nano::Observer
    * parameter to true
    *
    */
-  void layoutModelObj(openstudio::WorkspaceObject& workObj, bool force = false, bool recursive = true, bool locked = false,
+  void layoutModelObj(openstudio::WorkspaceObject& workspaceObj, bool force = false, bool recursive = true, bool locked = false,
                       bool hideChildren = false);
 
   /*! \brief sets the display precision for number fields
@@ -302,7 +302,7 @@ class MODELEDITOR_API InspectorGadget : public QWidget, public Nano::Observer
                           const std::string& name, const std::string& curVal, int index, const std::string& comment, bool exists, bool number,
                           bool real = false);
 
-  void layoutComboBox(QVBoxLayout* layout, QWidget* parent, openstudio::IddField& field, openstudio::IddFieldProperties& properties,
+  void layoutComboBox(QVBoxLayout* layout, QWidget* parent, openstudio::IddField& field, openstudio::IddFieldProperties& prop,
                       const std::string& name, const std::string& curVal, int index, const std::string& comment, bool exists);
 
   void createExtensibleToolBar(QVBoxLayout* layout, QWidget* parent, const openstudio::IddObjectProperties& props);

--- a/src/openstudio_app/OpenStudioApp.cpp
+++ b/src/openstudio_app/OpenStudioApp.cpp
@@ -453,8 +453,7 @@ void OpenStudioApp::newFromEmptyTemplateSlot() {
 }
 
 void OpenStudioApp::newFromTemplateSlot(NewFromTemplateEnum newFromTemplateEnum) {
-  m_osDocument = std::shared_ptr<OSDocument>(new OSDocument(componentLibrary(), resourcesPath(),
-                                                            boost::none, QString(), false, startTabIndex()));
+  m_osDocument = std::shared_ptr<OSDocument>(new OSDocument(componentLibrary(), resourcesPath(), boost::none, QString(), false, startTabIndex()));
 
   connectOSDocumentSignals();
 
@@ -553,8 +552,7 @@ void OpenStudioApp::importIdf() {
           processEvents();
         }
 
-        m_osDocument = std::shared_ptr<OSDocument>(new OSDocument(componentLibrary(), resourcesPath(), model,
-                                                                  QString(), false, startTabIndex()));
+        m_osDocument = std::shared_ptr<OSDocument>(new OSDocument(componentLibrary(), resourcesPath(), model, QString(), false, startTabIndex()));
         m_osDocument->markAsModified();
         // ETH: parent should change now ...
         //parent = m_osDocument->mainWindow();
@@ -680,8 +678,7 @@ void OpenStudioApp::importIFC() {
       processEvents();
     }
 
-    m_osDocument = std::shared_ptr<OSDocument>(new OSDocument(componentLibrary(), resourcesPath(), *model,
-                                                              QString(), false, startTabIndex()));
+    m_osDocument = std::shared_ptr<OSDocument>(new OSDocument(componentLibrary(), resourcesPath(), *model, QString(), false, startTabIndex()));
 
     m_osDocument->markAsModified();
 
@@ -743,8 +740,7 @@ void OpenStudioApp::import(OpenStudioApp::fileType type) {
         processEvents();
       }
 
-      m_osDocument = std::shared_ptr<OSDocument>(new OSDocument(componentLibrary(), resourcesPath(), *model,
-                                                                QString(), false, startTabIndex()));
+      m_osDocument = std::shared_ptr<OSDocument>(new OSDocument(componentLibrary(), resourcesPath(), *model, QString(), false, startTabIndex()));
       m_osDocument->markAsModified();
       // ETH: parent should change now ...
       //parent = m_osDocument->mainWindow();

--- a/src/openstudio_app/OpenStudioApp.hpp
+++ b/src/openstudio_app/OpenStudioApp.hpp
@@ -239,6 +239,8 @@ class OpenStudioApp : public OSAppBase
    */
   void writeLibraryPaths(std::vector<openstudio::path> paths);
 
+  int startTabIndex() const;
+
   QProcess* m_measureManagerProcess;
 
   openstudio::model::Model m_compLibrary;

--- a/src/openstudio_lib/MainRightColumnController.cpp
+++ b/src/openstudio_lib/MainRightColumnController.cpp
@@ -1157,17 +1157,6 @@ void MainRightColumnController::configureForHVACSystemsSubTab(int subTabID) {
   doc->openSidebar();
 }
 
-void MainRightColumnController::configureForBuildingSummarySubTab(int subTabID) {
-  std::shared_ptr<OSDocument> doc = OSAppBase::instance()->currentDocument();
-
-  setLibraryView(nullptr);
-  setMyModelView(nullptr);
-  setEditView(nullptr);
-
-  //doc->openSidebar();
-  doc->closeSidebar();
-}
-
 void MainRightColumnController::configureForOutputVariablesSubTab(int subTabID) {
   std::shared_ptr<OSDocument> doc = OSAppBase::instance()->currentDocument();
 

--- a/src/openstudio_lib/MainRightColumnController.hpp
+++ b/src/openstudio_lib/MainRightColumnController.hpp
@@ -113,8 +113,6 @@ class MainRightColumnController : public OSQObjectController
 
   void configureForHVACSystemsSubTab(int subTabID);
 
-  void configureForBuildingSummarySubTab(int subTabID);
-
   void configureForOutputVariablesSubTab(int subTabID);
 
   void configureForSimulationSettingsSubTab(int subTabID);

--- a/src/openstudio_lib/OSDocument.cpp
+++ b/src/openstudio_lib/OSDocument.cpp
@@ -133,8 +133,7 @@
 
 namespace openstudio {
 
-OSDocument::OSDocument(const openstudio::model::Model& library, const openstudio::path& resourcesPath, openstudio::model::OptionalModel model,
-                       QString filePath, bool isPlugin, int startTabIndex, int startSubTabIndex)
+OSDocument::OSDocument(const openstudio::model::Model& library, const openstudio::path& resourcesPath, openstudio::model::OptionalModel model, QString filePath, bool isPlugin, int startTabIndex, int startSubTabIndex)
   : OSQObjectController(),
     m_compLibrary(library),
     m_resourcesPath(resourcesPath),
@@ -142,9 +141,8 @@ OSDocument::OSDocument(const openstudio::model::Model& library, const openstudio
     m_onlineBclDialog(nullptr),
     m_localLibraryDialog(nullptr),
     m_savePath(filePath),
-    m_isPlugin(isPlugin),
-    m_startTabIndex(startTabIndex),
-    m_startSubTabIndex(startSubTabIndex) {
+    m_isPlugin(isPlugin)
+{
   QFile data(":openstudiolib.qss");
 
   static QString style;
@@ -229,6 +227,13 @@ OSDocument::OSDocument(const openstudio::model::Model& library, const openstudio
 
   if (initalizeWorkflow) {
     QTimer::singleShot(0, this, SLOT(addStandardMeasures()));
+  }
+
+  if (startTabIndex != m_verticalId) {
+    QTimer::singleShot(0, [=] {
+      this->onVerticalTabSelected(startTabIndex);
+      this->updateSubTabSelected(startSubTabIndex);
+    } );
   }
 }
 
@@ -657,20 +662,6 @@ void OSDocument::createTab(int verticalId) {
               &MainRightColumnController::configureForHVACSystemsSubTab);
 
       connect(m_mainTabController->mainContentWidget(), &MainTabView::tabSelected, this, &OSDocument::updateSubTabSelected);
-
-      break;
-
-    case BUILDING_SUMMARY:
-      //******************************************************************************************************
-      //
-      //// Summary
-      //
-      //m_summaryTabController = std::shared_ptr<SummaryTabController>( new SummaryTabController(m_model) );
-      //m_mainWindow->setView( m_summaryTabController->mainContentWidget(),BUILDING_SUMMARY );
-      ////connect(m_summaryTabController->mainContentWidget(), &MainTabView::tabSelected,
-      ////        m_mainRightColumnController.get(), &MainRightColumnController::configureForBuildingSummarySubTab);
-      //
-      //******************************************************************************************************
 
       break;
 
@@ -1169,9 +1160,6 @@ void OSDocument::onVerticalTabSelected(int verticalId) {
       if (qobject_cast<HVACSystemsTabController*>(m_mainTabController.get())) {
         qobject_cast<HVACSystemsTabController*>(m_mainTabController.get())->clearSceneSelection();
       }
-      break;
-    case BUILDING_SUMMARY:
-      m_mainRightColumnController->configureForBuildingSummarySubTab(m_subTabId);
       break;
     case OUTPUT_VARIABLES:
       m_mainRightColumnController->configureForOutputVariablesSubTab(m_subTabId);

--- a/src/openstudio_lib/OSDocument.cpp
+++ b/src/openstudio_lib/OSDocument.cpp
@@ -133,7 +133,8 @@
 
 namespace openstudio {
 
-OSDocument::OSDocument(const openstudio::model::Model& library, const openstudio::path& resourcesPath, openstudio::model::OptionalModel model, QString filePath, bool isPlugin, int startTabIndex, int startSubTabIndex)
+OSDocument::OSDocument(const openstudio::model::Model& library, const openstudio::path& resourcesPath, openstudio::model::OptionalModel model,
+                       QString filePath, bool isPlugin, int startTabIndex, int startSubTabIndex)
   : OSQObjectController(),
     m_compLibrary(library),
     m_resourcesPath(resourcesPath),
@@ -141,8 +142,7 @@ OSDocument::OSDocument(const openstudio::model::Model& library, const openstudio
     m_onlineBclDialog(nullptr),
     m_localLibraryDialog(nullptr),
     m_savePath(filePath),
-    m_isPlugin(isPlugin)
-{
+    m_isPlugin(isPlugin) {
   QFile data(":openstudiolib.qss");
 
   static QString style;
@@ -233,7 +233,7 @@ OSDocument::OSDocument(const openstudio::model::Model& library, const openstudio
     QTimer::singleShot(0, [=] {
       this->onVerticalTabSelected(startTabIndex);
       this->updateSubTabSelected(startSubTabIndex);
-    } );
+    });
   }
 }
 

--- a/src/openstudio_lib/OSDocument.hpp
+++ b/src/openstudio_lib/OSDocument.hpp
@@ -141,7 +141,7 @@ class OPENSTUDIO_API OSDocument : public OSQObjectController
 
   enum VerticalTabID
   {
-    SITE,
+    SITE = 0,
     SCHEDULES,
     CONSTRUCTIONS,
     LOADS,
@@ -151,7 +151,6 @@ class OPENSTUDIO_API OSDocument : public OSQObjectController
     SPACES,
     THERMAL_ZONES,
     HVAC_SYSTEMS,
-    BUILDING_SUMMARY,
     OUTPUT_VARIABLES,
     SIMULATION_SETTINGS,
     RUBY_SCRIPTS,
@@ -352,9 +351,6 @@ class OPENSTUDIO_API OSDocument : public OSQObjectController
   int m_mainTabId = 0;
   int m_subTabId = 0;
   bool m_isPlugin;
-
-  int m_startTabIndex;
-  int m_startSubTabIndex;
 
   int m_verticalId;
   std::vector<int> m_subTabIds;

--- a/src/shared_gui_components/OSConcepts.hpp
+++ b/src/shared_gui_components/OSConcepts.hpp
@@ -394,12 +394,12 @@ class CheckBoxConceptBoolReturnImpl : public CheckBoxConceptBoolReturn
 
   virtual ~CheckBoxConceptBoolReturnImpl() {}
 
-  virtual bool get(const ConceptProxy& t_obj) {
+  virtual bool get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual bool set(const ConceptProxy& t_obj, bool value) {
+  virtual bool set(const ConceptProxy& t_obj, bool value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }
@@ -769,24 +769,24 @@ class ValueEditConceptImpl : public ValueEditConcept<ValueType>
 
   virtual ~ValueEditConceptImpl() {}
 
-  virtual ValueType get(const ConceptProxy& t_obj) {
+  virtual ValueType get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual bool set(const ConceptProxy& t_obj, ValueType value) {
+  virtual bool set(const ConceptProxy& t_obj, ValueType value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }
 
-  virtual void reset(const ConceptProxy& t_obj) {
+  virtual void reset(const ConceptProxy& t_obj) override {
     if (m_reset) {
       DataSourceType obj = t_obj.cast<DataSourceType>();
       (*m_reset)(&obj);
     }
   }
 
-  virtual bool isDefaulted(const ConceptProxy& t_obj) {
+  virtual bool isDefaulted(const ConceptProxy& t_obj) override {
     if (m_isDefaulted) {
       DataSourceType obj = t_obj.cast<DataSourceType>();
       return (*m_isDefaulted)(&obj);
@@ -826,12 +826,12 @@ class OptionalValueEditConceptImpl : public OptionalValueEditConcept<ValueType>
 
   virtual ~OptionalValueEditConceptImpl() {}
 
-  virtual boost::optional<ValueType> get(const ConceptProxy& t_obj) {
+  virtual boost::optional<ValueType> get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual bool set(const ConceptProxy& t_obj, ValueType value) {
+  virtual bool set(const ConceptProxy& t_obj, ValueType value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }
@@ -869,24 +869,24 @@ class ValueEditVoidReturnConceptImpl : public ValueEditVoidReturnConcept<ValueTy
 
   virtual ~ValueEditVoidReturnConceptImpl() {}
 
-  virtual ValueType get(const ConceptProxy& t_obj) {
+  virtual ValueType get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual void set(const ConceptProxy& t_obj, ValueType value) {
+  virtual void set(const ConceptProxy& t_obj, ValueType value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }
 
-  virtual void reset(const ConceptProxy& t_obj) {
+  virtual void reset(const ConceptProxy& t_obj) override {
     if (m_reset) {
       DataSourceType obj = t_obj.cast<DataSourceType>();
       (*m_reset)(&obj);
     }
   }
 
-  virtual bool isDefaulted(const ConceptProxy& t_obj) {
+  virtual bool isDefaulted(const ConceptProxy& t_obj) override {
     if (m_isDefaulted) {
       DataSourceType obj = t_obj.cast<DataSourceType>();
       return (*m_isDefaulted)(&obj);
@@ -926,12 +926,12 @@ class OptionalValueEditVoidReturnConceptImpl : public OptionalValueEditVoidRetur
 
   virtual ~OptionalValueEditVoidReturnConceptImpl() {}
 
-  virtual boost::optional<ValueType> get(const ConceptProxy& t_obj) {
+  virtual boost::optional<ValueType> get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual void set(const ConceptProxy& t_obj, ValueType value) {
+  virtual void set(const ConceptProxy& t_obj, ValueType value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }
@@ -1132,24 +1132,24 @@ class QuantityEditConceptImpl : public QuantityEditConcept<ValueType>
 
   virtual ~QuantityEditConceptImpl() {}
 
-  virtual ValueType get(const ConceptProxy& t_obj) {
+  virtual ValueType get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual bool set(const ConceptProxy& t_obj, ValueType value) {
+  virtual bool set(const ConceptProxy& t_obj, ValueType value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }
 
-  virtual void reset(const ConceptProxy& t_obj) {
+  virtual void reset(const ConceptProxy& t_obj) override {
     if (m_reset) {
       DataSourceType obj = t_obj.cast<DataSourceType>();
       (*m_reset)(&obj);
     }
   }
 
-  virtual bool isDefaulted(const ConceptProxy& t_obj) {
+  virtual bool isDefaulted(const ConceptProxy& t_obj) override {
     if (m_isDefaulted) {
       DataSourceType obj = t_obj.cast<DataSourceType>();
       return (*m_isDefaulted)(&obj);
@@ -1211,12 +1211,12 @@ class OptionalQuantityEditConceptImpl : public OptionalQuantityEditConcept<Value
 
   virtual ~OptionalQuantityEditConceptImpl() {}
 
-  virtual boost::optional<ValueType> get(const ConceptProxy& t_obj) {
+  virtual boost::optional<ValueType> get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual bool set(const ConceptProxy& t_obj, ValueType value) {
+  virtual bool set(const ConceptProxy& t_obj, ValueType value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }
@@ -1280,24 +1280,24 @@ class QuantityEditVoidReturnConceptImpl : public QuantityEditVoidReturnConcept<V
 
   virtual ~QuantityEditVoidReturnConceptImpl() {}
 
-  virtual ValueType get(const ConceptProxy& t_obj) {
+  virtual ValueType get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual void set(const ConceptProxy& t_obj, ValueType value) {
+  virtual void set(const ConceptProxy& t_obj, ValueType value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }
 
-  virtual void reset(const ConceptProxy& t_obj) {
+  virtual void reset(const ConceptProxy& t_obj) override {
     if (m_reset) {
       DataSourceType obj = t_obj.cast<DataSourceType>();
       (*m_reset)(&obj);
     }
   }
 
-  virtual bool isDefaulted(const ConceptProxy& t_obj) {
+  virtual bool isDefaulted(const ConceptProxy& t_obj) override {
     if (m_isDefaulted) {
       DataSourceType obj = t_obj.cast<DataSourceType>();
       return (*m_isDefaulted)(&obj);
@@ -1361,12 +1361,12 @@ class OptionalQuantityEditVoidReturnConceptImpl : public OptionalQuantityEditVoi
 
   virtual ~OptionalQuantityEditVoidReturnConceptImpl() {}
 
-  virtual boost::optional<ValueType> get(const ConceptProxy& t_obj) {
+  virtual boost::optional<ValueType> get(const ConceptProxy& t_obj) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_getter(&obj);
   }
 
-  virtual void set(const ConceptProxy& t_obj, ValueType value) {
+  virtual void set(const ConceptProxy& t_obj, ValueType value) override {
     DataSourceType obj = t_obj.cast<DataSourceType>();
     return m_setter(&obj, value);
   }


### PR DESCRIPTION
One liner:
`OPENSTUDIO_APPLICATION_START_TAB_INDEX=9 ./OpenStudioApp.exe /path/to/in.osm`

Set permanently:
```
export OPENSTUDIO_APPLICATION_START_TAB_INDEX=9
./OpenStudioApp.exe /path/to/in.osm
```