### PR TITLE
Fix #219 - Add AirLoopHVAC "design return airflow fraction" to the App enStudioApplication and adjust OpenStudioPolicy to hide splitter/mixer

### DIFF
--- a/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -811,16 +811,20 @@
   </POLICY>
   <POLICY IddObjectType="OS_AirLoopHVAC">
     <rule IddField="Controller List Name" Access="HIDDEN"/>
-    <rule IddField="Availability Manager" Access="HIDDEN"/>
+    <rule IddField="Availability Manager List Name" Access="HIDDEN"/>
+    <rule IddField="Availability Schedule" Access="HIDDEN"/>
     <rule IddField="Branch List Name" Access="HIDDEN"/>
     <rule IddField="Connector List Name" Access="HIDDEN"/>
-    <rule IddField="Availability Schedule" Access="HIDDEN"/>
     <rule IddField="Supply Side Inlet Node Name" Access="HIDDEN"/>
     <rule IddField="Supply Side Outlet Node A" Access="HIDDEN"/>
     <rule IddField="Supply Side Outlet Node B" Access="HIDDEN"/>
     <rule IddField="Demand Side Outlet Node Name" Access="HIDDEN"/>
     <rule IddField="Demand Side Inlet Node A" Access="HIDDEN"/>
     <rule IddField="Demand Side Inlet Node B" Access="HIDDEN"/>
+    <rule IddField="Demand Mixer Name" Access="HIDDEN"/>
+    <rule IddField="Demand Splitter A Name" Access="HIDDEN"/>
+    <rule IddField="Demand Splitter B Name" Access="HIDDEN"/>
+    <rule IddField="Supply Splitter Name" Access="HIDDEN"/>
   </POLICY>
   <POLICY IddObjectType="OS_PlantLoop">
     <rule IddField="Plant Equipment Operation Scheme Name" Access="HIDDEN"/>


### PR DESCRIPTION
Fix #219 - Add AirLoopHVAC "design return airflow fraction" to the App enStudioApplication and adjust OpenStudioPolicy to hide splitter/mixer

## 1.1.0

![image](https://user-images.githubusercontent.com/5479063/120187165-c084df80-c214-11eb-9a71-6c324faceaa3.png)


## This PR

![image](https://user-images.githubusercontent.com/5479063/120187049-9af7d600-c214-11eb-824c-56f922a210b4.png)
