### PR TITLE
Misc fixes: don't orphan CLI when exiting the App to prevent a crash report on mac

### DIFF
--- a/src/openstudio_app/OpenStudioApp.cpp
+++ b/src/openstudio_app/OpenStudioApp.cpp
@@ -226,6 +226,8 @@ OpenStudioApp::OpenStudioApp(int& argc, char** argv)
 OpenStudioApp::~OpenStudioApp() {
   if (m_measureManagerProcess) {
     m_measureManagerProcess->disconnect();
+    m_measureManagerProcess->terminate();
+    m_measureManagerProcess->waitForFinished();
     delete m_measureManagerProcess;
     m_measureManagerProcess = nullptr;
   }

--- a/src/openstudio_app/OpenStudioApp.cpp
+++ b/src/openstudio_app/OpenStudioApp.cpp
@@ -226,7 +226,7 @@ OpenStudioApp::OpenStudioApp(int& argc, char** argv)
 OpenStudioApp::~OpenStudioApp() {
   if (m_measureManagerProcess) {
     m_measureManagerProcess->disconnect();
-    m_measureManagerProcess->terminate();
+    m_measureManagerProcess->kill();
     m_measureManagerProcess->waitForFinished();
     delete m_measureManagerProcess;
     m_measureManagerProcess = nullptr;

--- a/src/openstudio_app/OpenStudioApp.cpp
+++ b/src/openstudio_app/OpenStudioApp.cpp
@@ -192,7 +192,7 @@ OpenStudioApp::OpenStudioApp(int& argc, char** argv)
   setQuitOnLastWindowClosed(false);
 
   m_startupMenu = std::shared_ptr<StartupMenu>(new StartupMenu());
-  connect(m_startupMenu.get(), &StartupMenu::exitClicked, this, &OpenStudioApp::quit);
+  connect(m_startupMenu.get(), &StartupMenu::exitClicked, this, &OpenStudioApp::quit, Qt::QueuedConnection);
   connect(m_startupMenu.get(), &StartupMenu::importClicked, this, &OpenStudioApp::importIdf);
   connect(m_startupMenu.get(), &StartupMenu::importgbXMLClicked, this, &OpenStudioApp::importgbXML);
   connect(m_startupMenu.get(), &StartupMenu::importSDDClicked, this, &OpenStudioApp::importSDD);
@@ -1218,8 +1218,8 @@ void OpenStudioApp::revertToSaved() {
 
 void OpenStudioApp::connectOSDocumentSignals() {
   OS_ASSERT(m_osDocument);
-  connect(m_osDocument.get(), &OSDocument::closeClicked, this, &OpenStudioApp::onCloseClicked);
-  connect(m_osDocument.get(), &OSDocument::exitClicked, this, &OpenStudioApp::quit);
+  connect(m_osDocument.get(), &OSDocument::closeClicked, this, &OpenStudioApp::onCloseClicked, Qt::QueuedConnection);
+  connect(m_osDocument.get(), &OSDocument::exitClicked, this, &OpenStudioApp::quit, Qt::QueuedConnection);
   connect(m_osDocument.get(), &OSDocument::importClicked, this, &OpenStudioApp::importIdf);
   connect(m_osDocument.get(), &OSDocument::importgbXMLClicked, this, &OpenStudioApp::importgbXML);
   connect(m_osDocument.get(), &OSDocument::importSDDClicked, this, &OpenStudioApp::importSDD);

--- a/src/openstudio_lib/GeometryPreviewView.cpp
+++ b/src/openstudio_lib/GeometryPreviewView.cpp
@@ -141,8 +141,8 @@ PreviewWebView::PreviewWebView(bool isIP, const model::Model& model, QWidget* t_
 }
 
 PreviewWebView::~PreviewWebView() {
-  delete m_view;
   delete m_page;
+  delete m_view;
 }
 
 void PreviewWebView::refreshClicked() {

--- a/src/openstudio_lib/openstudio.qrc
+++ b/src/openstudio_lib/openstudio.qrc
@@ -615,6 +615,10 @@
     <file alias="shared_gui_components/images/duplicate_off.png">../shared_gui_components/images/duplicate_off.png</file>
     <file alias="shared_gui_components/images/duplicate_over.png">../shared_gui_components/images/duplicate_over.png</file>
     <file alias="shared_gui_components/images/duplicate_press.png">../shared_gui_components/images/duplicate_press.png</file>
+    <file alias="shared_gui_components/images/duplicate_softer_disabled.png">../shared_gui_components/images/duplicate_softer_disabled.png</file>
+    <file alias="shared_gui_components/images/duplicate_softer_off.png">../shared_gui_components/images/duplicate_softer_off.png</file>
+    <file alias="shared_gui_components/images/duplicate_softer_over.png">../shared_gui_components/images/duplicate_softer_over.png</file>
+    <file alias="shared_gui_components/images/duplicate_softer_press.png">../shared_gui_components/images/duplicate_softer_press.png</file>
     <file alias="shared_gui_components/images/energyplus_measure_icon.png">../shared_gui_components/images/energyplus_measure_icon.png</file>
     <file alias="shared_gui_components/images/error-alert.png">../shared_gui_components/images/error-alert.png</file>
     <file alias="shared_gui_components/images/fast_forward.png">../shared_gui_components/images/fast_forward.png</file>


### PR DESCRIPTION
Fix #369 