### PR TITLE
Fix #372 - writeSettings / writeLibraryPaths warn user if settings can't be written to

### DIFF
--- a/src/openstudio_app/OpenStudioApp.cpp
+++ b/src/openstudio_app/OpenStudioApp.cpp
@@ -132,6 +132,7 @@
 #include <QTcpServer>
 #include <QtConcurrent>
 #include <QtGlobal>
+#include <QSettings>
 
 #include <openstudio/OpenStudio.hxx>
 #include <openstudio/utilities/idd/IddEnums.hxx>
@@ -1173,6 +1174,10 @@ void OpenStudioApp::writeSettings() {
   QString organizationName = QCoreApplication::organizationName();
   QString applicationName = QCoreApplication::applicationName();
   QSettings settings(organizationName, applicationName);
+  if (!settings.isWritable()) {
+    QMessageBox::warning(nullptr, tr("Settings file not writable"),
+                         tr("Your settings file '") + settings.fileName() + tr("' is not writable. Adjust the file permissions"));
+  }
   settings.setValue("lastPath", lastPath());
 }
 
@@ -1301,6 +1306,11 @@ void OpenStudioApp::writeLibraryPaths(std::vector<openstudio::path> paths) {
   auto defaultPaths = defaultLibraryPaths();
 
   QSettings settings(QCoreApplication::organizationName(), QCoreApplication::applicationName());
+
+  if (!settings.isWritable()) {
+    QMessageBox::warning(nullptr, tr("Settings file not writable"),
+                         tr("Your settings file '") + settings.fileName() + tr("' is not writable. Adjust the file permissions"));
+  }
 
   if (paths == defaultPaths) {
     settings.remove("library");


### PR DESCRIPTION
Fix #372 - writeSettings / writeLibraryPaths warn user if settings can't be written to