### PR TITLE
Fix #379 - AirLoopHVAC Control Tab resets some economizer selections

### DIFF
--- a/src/openstudio_lib/HVACSystemsView.cpp
+++ b/src/openstudio_lib/HVACSystemsView.cpp
@@ -535,6 +535,8 @@ MechanicalVentilationView::MechanicalVentilationView() : QWidget() {
   economizerComboBox->addItem("Differential Dry Bulb", "DifferentialDryBulb");
   economizerComboBox->addItem("Differential Enthalpy", "DifferentialEnthalpy");
   economizerComboBox->addItem("Fixed Dewpoint and Dry Bulb", "FixedDewPointAndDryBulb");
+  economizerComboBox->addItem("ElectronicEnthalpy", "ElectronicEnthalpy");
+  economizerComboBox->addItem("Differential Dry Bulb and Enthalpy", "DifferentialDryBulbAndEnthalpy");
   economizerComboBox->addItem("No Economizer", "NoEconomizer");
   economizerHBoxLayout->addWidget(economizerComboBox);
 


### PR DESCRIPTION
Fix #379 - AirLoopHVAC Control Tab resets some economizer selections

Note: in the process I opened https://github.com/NREL/OpenStudio/issues/4416. Mostly because of the lack for validEconomizerControlTypeValues or economizerControlTypeValues method so I could have a chance of dynamically populating the the combobox to avoid new IDD choices being missing in the app.

@eringold FYI