### PR TITLE
Fix #131 - Allow to edit WaterUseConnections

### DIFF
--- a/src/openstudio_lib/ServiceWaterScene.cpp
+++ b/src/openstudio_lib/ServiceWaterScene.cpp
@@ -31,6 +31,9 @@
 #include "GridItem.hpp"
 #include "ServiceWaterGridItems.hpp"
 #include "OSAppBase.hpp"
+#include "OSDocument.hpp"
+#include "MainRightColumnController.hpp"
+
 #include <openstudio/model/Model.hpp>
 #include <openstudio/model/Model_Impl.hpp>
 #include <openstudio/model/ModelObject.hpp>
@@ -41,6 +44,7 @@
 #include <openstudio/model/WaterUseConnections_Impl.hpp>
 #include <openstudio/model/WaterUseEquipment.hpp>
 #include <openstudio/model/WaterUseEquipment_Impl.hpp>
+
 #include <QTimer>
 
 namespace openstudio {
@@ -49,9 +53,8 @@ ServiceWaterScene::ServiceWaterScene(const model::Model& model) : GridScene(), m
   //m_model.getImpl<model::detail::Model_Impl>().get()->addWorkspaceObjectPtr.connect<ServiceWaterScene, &ServiceWaterScene::onAddedWorkspaceObject>(this);
   connect(OSAppBase::instance(), &OSAppBase::workspaceObjectAddedPtr, this, &ServiceWaterScene::onAddedWorkspaceObject, Qt::QueuedConnection);
 
-  m_model.getImpl<model::detail::Model_Impl>()
-    .get()
-    ->removeWorkspaceObjectPtr.connect<ServiceWaterScene, &ServiceWaterScene::onRemovedWorkspaceObject>(this);
+  m_model.getImpl<model::detail::Model_Impl>()->removeWorkspaceObjectPtr.connect<ServiceWaterScene, &ServiceWaterScene::onRemovedWorkspaceObject>(
+    this);
 
   layout();
 }
@@ -84,7 +87,7 @@ void ServiceWaterScene::onAddedWorkspaceObject(std::shared_ptr<openstudio::detai
 
 void ServiceWaterScene::onRemovedWorkspaceObject(std::shared_ptr<openstudio::detail::WorkspaceObject_Impl> wPtr,
                                                  const openstudio::IddObjectType& type, const openstudio::UUID& uuid) {
-  model::detail::WaterUseConnections_Impl* hvac_impl = dynamic_cast<model::detail::WaterUseConnections_Impl*>(wPtr.get());
+  auto* hvac_impl = dynamic_cast<model::detail::WaterUseConnections_Impl*>(wPtr.get());
   if (hvac_impl) {
     m_dirty = true;
 
@@ -101,10 +104,13 @@ WaterUseConnectionsDetailScene::WaterUseConnectionsDetailScene(const model::Wate
           Qt::QueuedConnection);
 
   model.getImpl<model::detail::Model_Impl>()
-    .get()
     ->removeWorkspaceObjectPtr.connect<WaterUseConnectionsDetailScene, &WaterUseConnectionsDetailScene::onRemovedWorkspaceObject>(this);
 
   layout();
+
+  // Display the object in MainRightColumnController for editing (name in particular)
+  model::OptionalModelObject mo = m_waterUseConnections;
+  OSAppBase::instance()->currentDocument()->mainRightColumnController()->inspectModelObject(mo, false);
 }
 
 model::WaterUseConnections WaterUseConnectionsDetailScene::waterUseConnections() const {
@@ -118,14 +124,14 @@ void WaterUseConnectionsDetailScene::layout() {
     delete *it;
   }
 
-  auto backgroundItem = new WaterUseConnectionsDetailItem(this);
+  auto* backgroundItem = new WaterUseConnectionsDetailItem(this);
 
   Q_UNUSED(backgroundItem);
 }
 
 void WaterUseConnectionsDetailScene::onAddedWorkspaceObject(std::shared_ptr<openstudio::detail::WorkspaceObject_Impl> wPtr,
                                                             const openstudio::IddObjectType& type, const openstudio::UUID& uuid) {
-  model::detail::WaterUseEquipment_Impl* hvac_impl = dynamic_cast<model::detail::WaterUseEquipment_Impl*>(wPtr.get());
+  auto* hvac_impl = dynamic_cast<model::detail::WaterUseEquipment_Impl*>(wPtr.get());
   if (hvac_impl) {
     m_dirty = true;
 
@@ -135,7 +141,7 @@ void WaterUseConnectionsDetailScene::onAddedWorkspaceObject(std::shared_ptr<open
 
 void WaterUseConnectionsDetailScene::onRemovedWorkspaceObject(std::shared_ptr<openstudio::detail::WorkspaceObject_Impl> wPtr,
                                                               const openstudio::IddObjectType& type, const openstudio::UUID& uuid) {
-  model::detail::WaterUseEquipment_Impl* hvac_impl = dynamic_cast<model::detail::WaterUseEquipment_Impl*>(wPtr.get());
+  auto* hvac_impl = dynamic_cast<model::detail::WaterUseEquipment_Impl*>(wPtr.get());
   if (hvac_impl) {
     m_dirty = true;
 

--- a/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -1739,4 +1739,12 @@
     <rule IddField="Main Model Program Calling Manager Name" Access="HIDDEN"/>
     <rule IddField="Main Model Program Name" Access="HIDDEN"/>
   </POLICY>
+  <POLICY IddObjectType="OS_WaterUse_Connections">
+    <rule IddField="Inlet Node Name" Access="HIDDEN"/>
+    <rule IddField="Outlet Node Name" Access="HIDDEN"/>
+    <rule IddField="Water Use Equipment Name" Access="HIDDEN"/>
+    <!-- REMOVE ONCE IMPLEMENTED IN SDK -->
+    <rule IddField="Supply Water Storage Tank Name" Access="HIDDEN"/>
+    <rule IddField="Reclamation Water Storage Tank Name" Access="HIDDEN"/>
+  </POLICY>
 </ROOT>


### PR DESCRIPTION
- Fix #131
-  Allow to edit WaterUseConnections

The way I do it is to automatically display it in the MainRightColumnController when you switch to the detailed view

![131](https://user-images.githubusercontent.com/5479063/139446733-d85f5d7a-05ad-4dd7-ab8e-f14b76986b5d.gif)


