### PR TITLE
Allow simulation if run socket cannot be opened

### DIFF
--- a/src/openstudio_lib/RunTabView.cpp
+++ b/src/openstudio_lib/RunTabView.cpp
@@ -182,6 +182,7 @@ void RunView::onRunProcessFinished(int exitCode, QProcess::ExitStatus status) {
   LOG(Debug, "run finished");
   m_playButton->setChecked(false);
   m_state = State::stopped;
+  m_progressBar->setMaximum(State::complete);
   m_progressBar->setValue(State::complete);
 
   std::shared_ptr<OSDocument> osdocument = OSAppBase::instance()->currentDocument();
@@ -228,10 +229,17 @@ void RunView::playButtonClicked(bool t_checked) {
     OS_ASSERT(exists(workflowPath));
 
     auto workflowJSONPath = QString::fromStdString(workflowPath.string());
-    QStringList arguments;
-    arguments << "run"
-              << "-s" << QString::number(m_runTcpServer->serverPort()) << "-w" << workflowJSONPath;
 
+    unsigned port = m_runTcpServer->serverPort();
+    bool haveConnection = (port != 0);
+    
+    QStringList arguments;
+    if (haveConnection) {
+      arguments << "run" << "-s" << QString::number(port) << "-w" << workflowJSONPath;
+    } else {
+      arguments << "run" << "-w" << workflowJSONPath;
+    }
+ 
     LOG(Debug, "openstudioExePath='" << toString(openstudioExePath) << "'");
     LOG(Debug, "run arguments" << arguments.join(";").toStdString());
 
@@ -244,10 +252,26 @@ void RunView::playButtonClicked(bool t_checked) {
     if (exists(stderrPath)) {
       remove(stderrPath);
     }
-
-    m_progressBar->setValue(0);
     m_state = State::stopped;
     m_textInfo->clear();
+
+    if (haveConnection) {
+      m_progressBar->setMinimum(0);
+      m_progressBar->setMaximum(State::complete);
+      m_progressBar->setValue(0);
+    } else {
+      m_progressBar->setMinimum(0);
+      m_progressBar->setMaximum(0);
+      m_progressBar->setValue(0);
+
+      m_textInfo->setTextColor(Qt::black);
+      m_textInfo->setFontPointSize(18);
+      m_textInfo->append("Could not open socket connection to OpenStudio CLI.");
+      m_textInfo->setFontPointSize(15);
+      m_textInfo->append("Live simulation feedback during run not available.");
+      m_textInfo->append("View simulation directory when run is complete.");
+    }
+    
     m_runProcess->setStandardOutputFile(toQString(stdoutPath));
     m_runProcess->setStandardErrorFile(toQString(stderrPath));
     m_runProcess->start(openstudioExePath, arguments);

--- a/src/openstudio_lib/RunTabView.cpp
+++ b/src/openstudio_lib/RunTabView.cpp
@@ -232,14 +232,16 @@ void RunView::playButtonClicked(bool t_checked) {
 
     unsigned port = m_runTcpServer->serverPort();
     bool haveConnection = (port != 0);
-    
+
     QStringList arguments;
     if (haveConnection) {
-      arguments << "run" << "-s" << QString::number(port) << "-w" << workflowJSONPath;
+      arguments << "run"
+                << "-s" << QString::number(port) << "-w" << workflowJSONPath;
     } else {
-      arguments << "run" << "-w" << workflowJSONPath;
+      arguments << "run"
+                << "-w" << workflowJSONPath;
     }
- 
+
     LOG(Debug, "openstudioExePath='" << toString(openstudioExePath) << "'");
     LOG(Debug, "run arguments" << arguments.join(";").toStdString());
 
@@ -271,7 +273,7 @@ void RunView::playButtonClicked(bool t_checked) {
       m_textInfo->append("Live simulation feedback during run not available.");
       m_textInfo->append("View simulation directory when run is complete.");
     }
-    
+
     m_runProcess->setStandardOutputFile(toQString(stdoutPath));
     m_runProcess->setStandardErrorFile(toQString(stderrPath));
     m_runProcess->start(openstudioExePath, arguments);


### PR DESCRIPTION
Fixes #483

May want to go further and allow app to run if measure manager is not available