### PR TITLE
Increase stack size on Windows CI builds

### DIFF
--- a/src/openstudio_app/CMakeLists.txt
+++ b/src/openstudio_app/CMakeLists.txt
@@ -132,7 +132,9 @@ add_executable(${target_name}
 
 if (NINJA)
   target_compile_definitions(${target_name} PRIVATE NINJA=1)
-elseif(WIN32)
+endif()
+
+if(WIN32)
   # increase stack size
   target_link_options(${target_name} PRIVATE /STACK:8388608)
 endif()


### PR DESCRIPTION
Stack size was not getting increased on Windows CI because Ninja generator was used