### PR TITLE
Additional output to run tab

### DIFF
--- a/src/openstudio_lib/RunTabView.cpp
+++ b/src/openstudio_lib/RunTabView.cpp
@@ -230,6 +230,9 @@ void RunView::playButtonClicked(bool t_checked) {
     auto workflowJSONPath = QString::fromStdString(workflowPath.string());
     QStringList arguments;
     arguments << "run"
+              << "--show-stdout"
+              << "--style-stdout"
+              << "--add-timings"
               << "-s" << QString::number(m_runTcpServer->serverPort()) << "-w" << workflowJSONPath;
 
     LOG(Debug, "openstudioExePath='" << toString(openstudioExePath) << "'");


### PR DESCRIPTION
Add additional arguments to the run command, needs OS 3.4.0.  We should consider removing the socket and just use stdout.

Fixes #110
Fixes #437