### PR TITLE
[#501] DesignHeatRecoveryWaterFlowRate field

### DIFF
--- a/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -585,7 +585,6 @@
     <rule IddField="Electric Input to Cooling Output Ratio Function of Part Load Ratio Curve Name" Access="LOCKED"/>
     <rule IddField="Condenser Inlet Node Name" Access="HIDDEN"/>
     <rule IddField="Condenser Outlet Node Name" Access="HIDDEN"/>
-    <rule IddField="Design Heat Recovery Water Flow Rate" Access="HIDDEN"/>
     <rule IddField="Heat Recovery Inlet Node Name" Access="HIDDEN"/>
     <rule IddField="Heat Recovery Outlet Node Name" Access="HIDDEN"/>
     <rule IddField="Basin Heater Capacity" Access="HIDDEN"/>


### PR DESCRIPTION
* Fix #501

Enable the DesignHeatRecoveryWaterFlowRate field for ChillerElectricEIR objects
![design heat recovery water flow rate field](https://user-images.githubusercontent.com/97246208/167428981-bfb352ab-04e5-4854-9aef-788cf08c5db1.png)


