### PR TITLE
Fix #551 - Allow connecting a VRF Terminal from "MyModel" to a VRF System

### DIFF
--- a/src/openstudio_lib/library/OpenStudioPolicy.xml
+++ b/src/openstudio_lib/library/OpenStudioPolicy.xml
@@ -1075,7 +1075,7 @@
     <rule IddField="Cooling Capacity Modifier Curve Function of Flow Fraction" Access="LOCKED"/>
   </POLICY>
   <POLICY IddObjectType="OS_AirConditioner_VariableRefrigerantFlow">
-    <rule IddField="Condenser Type" Access="HIDDEN"/>
+    <rule IddField="Condenser Type" Access="LOCKED"/>
     <rule IddField="Condenser Inlet Node" Access="HIDDEN"/>
     <rule IddField="Condenser Outlet Node" Access="HIDDEN"/>
     <rule IddField="Supply Water Storage Tank" Access="HIDDEN"/>


### PR DESCRIPTION
- Fix #551 
- Allow connecting a VRF Terminal from "MyModel" to a VRF System and adjust display of VRF COntroller when connected to AirLoopHVAC

![551_VRF](https://user-images.githubusercontent.com/5479063/175063672-ceaee8e7-df4c-45ec-8046-990dfef78470.gif)



@Ski90Moo