### PR TITLE
Fix #145 - Allow reordering HVACComponent on Loop via drag and drop

### DIFF
--- a/src/openstudio_lib/GridItem.cpp
+++ b/src/openstudio_lib/GridItem.cpp
@@ -147,10 +147,13 @@ bool hasSPM(model::Node& node) {
 bool isNotSplitterMixerNodesPred(const model::HVACComponent& modelObject) {
   auto iddObjectType = modelObject.iddObjectType();
 
-  return !((iddObjectType == openstudio::IddObjectType::OS_AirLoopHVAC_ZoneSplitter)
+  return !((iddObjectType == openstudio::IddObjectType::OS_Node)  //
+           || (iddObjectType == openstudio::IddObjectType::OS_AirLoopHVAC_ZoneSplitter)
            || (iddObjectType == openstudio::IddObjectType::OS_AirLoopHVAC_ZoneMixer)
            || (iddObjectType == openstudio::IddObjectType::OS_AirLoopHVAC_SupplyPlenum)
-           || (iddObjectType == openstudio::IddObjectType::OS_AirLoopHVAC_ReturnPlenum) || (iddObjectType == openstudio::IddObjectType::OS_Node));
+           || (iddObjectType == openstudio::IddObjectType::OS_AirLoopHVAC_ReturnPlenum)
+           || (iddObjectType == openstudio::IddObjectType::OS_Connector_Mixer)
+           || (iddObjectType == openstudio::IddObjectType::OS_Connector_Splitter));
 }
 
 ModelObjectGraphicsItem::ModelObjectGraphicsItem(QGraphicsItem* parent)

--- a/src/openstudio_lib/GridItem.hpp
+++ b/src/openstudio_lib/GridItem.hpp
@@ -34,6 +34,8 @@
 #include <QCoreApplication>
 #include <QPixmap>
 #include <QPointer>
+#include <QPointF>
+
 #include <openstudio/nano/nano_signal_slot.hpp>  // Signal-Slot replacement
 #include <openstudio/model/ModelObject.hpp>
 #include <openstudio/model/Node.hpp>
@@ -62,7 +64,7 @@ class ModelObjectGraphicsItem
  public:
   explicit ModelObjectGraphicsItem(QGraphicsItem* parent = nullptr);
 
-  ~ModelObjectGraphicsItem() {}
+  ~ModelObjectGraphicsItem() = default;
 
   void setEnableHighlight(bool highlight);
 
@@ -75,6 +77,10 @@ class ModelObjectGraphicsItem
   void hoverEnterEvent(QGraphicsSceneHoverEvent* event) override;
 
   void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) override;
+
+  void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) override;
+  void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
+  void mouseMoveEvent(QGraphicsSceneMouseEvent* event) override;
 
   virtual void setModelObject(model::OptionalModelObject modelObject);
 
@@ -106,6 +112,10 @@ class ModelObjectGraphicsItem
   RemoveButtonItem* m_removeButtonItem;
 
   bool m_enableHighlight;
+
+  bool m_draggable;
+  bool m_mouseDown;
+  QPointF m_dragStartPosition;
 
  private slots:
 

--- a/src/openstudio_lib/GridItem.hpp
+++ b/src/openstudio_lib/GridItem.hpp
@@ -88,6 +88,9 @@ class ModelObjectGraphicsItem
 
   void setDeletable(bool deletable);
 
+  bool draggable() const;
+  void setDraggable(bool draggable);
+
  signals:
 
   void modelObjectSelected(model::OptionalModelObject&, bool readOnly);


### PR DESCRIPTION
* Fix #145

![reorder_loop_comps](https://user-images.githubusercontent.com/5479063/231425246-7fd50ecc-f092-46e1-8732-22dfd28af48a.gif)

As can be seen above, I can't move a Node, or a splitter / mixer, or an OutdoorAirSystem

## TESTING WELCOME: TRY CREATIVE WAYS TO MAKE IT CRASH PLEASE!