### PR TITLE
Update to Google Analytics 4

### DIFF
--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -563,7 +563,6 @@ jobs:
          -DCPACK_SOURCE_TZ:BOOL=${{ env.CPACK_SOURCE_TZ }} -DCPACK_SOURCE_ZIP:BOOL=${{ env.CPACK_SOURCE_ZIP }} ^
          -DANALYTICS_API_SECRET:STRING=${{secrets.ANALYTICS_API_SECRET }} -DANALYTICS_MEASUREMENT_ID:STRING=${{secrets.ANALYTICS_MEASUREMENT_ID }} ^
          ../
-        type src\openstudio_lib\AnalyticsHelperSecrets.hxx
         ninja
         ninja package
 
@@ -615,7 +614,6 @@ jobs:
       run: |
         set -x
         echo "Building with $N threads"
-        cat src/openstudio_lib/AnalyticsHelperSecrets.hxx
         cmake --build . --target package -j $N --config $BUILD_TYPE
 
     - name: Test bed Sign inner portable executable files and exe package (Windows)

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -561,7 +561,9 @@ jobs:
          -DCPACK_BINARY_TXZ:BOOL=${{ env.CPACK_BINARY_TXZ }} -DCPACK_BINARY_TZ:BOOL=${{ env.CPACK_BINARY_TZ }} -DCPACK_SOURCE_RPM:BOOL=${{ env.CPACK_SOURCE_RPM }} ^
          -DCPACK_SOURCE_TBZ2:BOOL=${{ env.CPACK_SOURCE_TBZ2 }} -DCPACK_SOURCE_TGZ:BOOL=${{ env.CPACK_SOURCE_TGZ }} -DCPACK_SOURCE_TXZ:BOOL=${{ env.CPACK_SOURCE_TXZ }} ^
          -DCPACK_SOURCE_TZ:BOOL=${{ env.CPACK_SOURCE_TZ }} -DCPACK_SOURCE_ZIP:BOOL=${{ env.CPACK_SOURCE_ZIP }} ^
+         -DANALYTICS_API_SECRET:STRING=${{secrets.ANALYTICS_API_SECRET }} -DANALYTICS_MEASUREMENT_ID:STRING=${{secrets.ANALYTICS_MEASUREMENT_ID }} ^
          ../
+        type src\openstudio_lib\AnalyticsHelperSecrets.hxx
         ninja
         ninja package
 
@@ -586,6 +588,7 @@ jobs:
          -DCPACK_BINARY_TXZ:BOOL=$CPACK_BINARY_TXZ -DCPACK_BINARY_TZ:BOOL=$CPACK_BINARY_TZ -DCPACK_SOURCE_RPM:BOOL=$CPACK_SOURCE_RPM \
          -DCPACK_SOURCE_TBZ2:BOOL=$CPACK_SOURCE_TBZ2 -DCPACK_SOURCE_TGZ:BOOL=$CPACK_SOURCE_TGZ -DCPACK_SOURCE_TXZ:BOOL=$CPACK_SOURCE_TXZ \
          -DCPACK_SOURCE_TZ:BOOL=$CPACK_SOURCE_TZ -DCPACK_SOURCE_ZIP:BOOL=$CPACK_SOURCE_ZIP \
+         -DANALYTICS_API_SECRET:STRING=${{secrets.ANALYTICS_API_SECRET }} -DANALYTICS_MEASUREMENT_ID:STRING=${{secrets.ANALYTICS_MEASUREMENT_ID }} \
          ../
 
     # Note: JM 2020-07-22 This is an example of how to get a config log for a failed conan dependency build (no binary available)
@@ -612,6 +615,7 @@ jobs:
       run: |
         set -x
         echo "Building with $N threads"
+        cat src/openstudio_lib/AnalyticsHelperSecrets.hxx
         cmake --build . --target package -j $N --config $BUILD_TYPE
 
     - name: Test bed Sign inner portable executable files and exe package (Windows)

--- a/src/openstudio_lib/AnalyticsHelper.cpp
+++ b/src/openstudio_lib/AnalyticsHelper.cpp
@@ -62,12 +62,11 @@ void AnalyticsHelper::sendAnalytics(const QString& analyticsId, int verticalTabI
   QUrlQuery query(QString::fromUtf8("https://www.google-analytics.com/mp/collect?"));
   query.addQueryItem("api_secret", apiSecret());
   query.addQueryItem("measurement_id", measurementId());
-  QString url = query.query();
+
   QNetworkRequest request(query.query());
   request.setRawHeader("Content-Type", "application/json");
 
   QString tab = QString("Tab-%1").arg(verticalTabIndex);
-  QString version = toQString(openstudio::openStudioApplicationVersionWithPrerelease());
 
   QJsonObject selectContentParams;
   selectContentParams["content_type"] = "OSAppTab";

--- a/src/openstudio_lib/AnalyticsHelperSecrets.hxx.in
+++ b/src/openstudio_lib/AnalyticsHelperSecrets.hxx.in
@@ -27,77 +27,21 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#include "AnalyticsHelper.hpp"
-#include "AnalyticsHelperSecrets.hxx"
+#ifndef OPENSTUDIO_ANALYTICSHELPER_SECRETS_HXX
+#define OPENSTUDIO_ANALYTICSHELPER_SECRETS_HXX
 
-#include "../model_editor/Application.hpp"
-#include "../model_editor/Utilities.hpp"
-#include "../utilities/OpenStudioApplicationPathHelpers.hpp"
-
-#include <QByteArray>
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QNetworkAccessManager>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
-#include <QNetworkRequest>
 #include <QString>
-#include <QUrlQuery>
 
 namespace openstudio {
 
-AnalyticsHelper::AnalyticsHelper(QObject* parent) : QObject(parent), m_networkAccessManager(new QNetworkAccessManager(this)) {
-  m_networkAccessManager->setAutoDeleteReplies(true);
+inline QString apiSecret() {
+  return "${ANALYTICS_API_SECRET}";
 }
 
-AnalyticsHelper::~AnalyticsHelper() {
-  // cancel all futures
-  delete m_networkAccessManager;
-}
-
-void AnalyticsHelper::sendAnalytics(const QString& analyticsId, int verticalTabIndex) {
-
-  // https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events
-  QUrlQuery query(QString::fromUtf8("https://www.google-analytics.com/mp/collect?"));
-  query.addQueryItem("api_secret", apiSecret());
-  query.addQueryItem("measurement_id", measurementId());
-  QString url = query.query();
-  QNetworkRequest request(query.query());
-  request.setRawHeader("Content-Type", "application/json");
-
-  QString tab = QString("Tab-%1").arg(verticalTabIndex);
-  QString version = toQString(openstudio::openStudioApplicationVersionWithPrerelease());
-
-  QJsonObject selectContentParams;
-  selectContentParams["content_type"] = "OSAppTab";
-  selectContentParams["content_id"] = tab;
-
-  QJsonObject selectContentEvent;
-  selectContentEvent["name"] = "select_content";
-  selectContentEvent["params"] = selectContentParams;
-
-  QJsonArray events;
-  events.append(selectContentEvent);
-
-  QJsonObject json;
-  json["client_id"] = analyticsId;
-  json["non_personalized_ads"] = true;
-  json["events"] = events;
-
-  QJsonDocument doc(json);
-  QByteArray data = doc.toJson();
-  m_networkAccessManager->post(request, data);
-
-  // for debugging
-  //auto reply = m_networkAccessManager->post(request, data);
-  //while (reply->isRunning() && !reply->isFinished())
-  //{
-  //  Application::instance().processEvents();
-  //}
-  //auto error = reply->error();
-  //auto statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
-  //delete reply;
+inline QString measurementId() {
+  return "${ANALYTICS_MEASUREMENT_ID}";
 }
 
 }  // namespace openstudio
+
+#endif  // OPENSTUDIO_ANALYTICSHELPER_SECRETS_HXX

--- a/src/openstudio_lib/CMakeLists.txt
+++ b/src/openstudio_lib/CMakeLists.txt
@@ -3,6 +3,16 @@ set(target_name openstudio_lib)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${QT_INCLUDES})
 
+if(DEFINED ENV{ANALYTICS_API_SECRET})
+  set(ANALYTICS_API_SECRET $ENV{ANALYTICS_API_SECRET})
+endif()
+
+if(DEFINED ENV{ANALYTICS_MEASUREMENT_ID})
+  set(ANALYTICS_MEASUREMENT_ID $ENV{ANALYTICS_MEASUREMENT_ID})
+endif()
+
+CONFIGURE_FILE_WITH_CHECKSUM("AnalyticsHelperSecrets.hxx.in" "${CMAKE_CURRENT_BINARY_DIR}/AnalyticsHelperSecrets.hxx")
+
 # source files
 set(${target_name}_SRC
   AnalyticsHelper.cpp
@@ -751,6 +761,7 @@ AddPCH(${target_name})
 set(${target_name}_test_src
   test/OpenStudioLibFixture.hpp
   test/OpenStudioLibFixture.cpp
+  test/AnalyticsHelper_GTest.cpp
   test/DesignDays_GTest.cpp
   test/FacilityStories_GTest.cpp
   test/FacilityShading_GTest.cpp

--- a/src/openstudio_lib/test/AnalyticsHelper_GTest.cpp
+++ b/src/openstudio_lib/test/AnalyticsHelper_GTest.cpp
@@ -1,0 +1,43 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2020-2023, OpenStudio Coalition and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "OpenStudioLibFixture.hpp"
+
+#include "../AnalyticsHelper.hpp"
+#include <AnalyticsHelperSecrets.hxx>
+
+
+using namespace openstudio;
+
+TEST_F(OpenStudioLibFixture, AnalyticsHelperSecrets) {
+  EXPECT_EQ(false, apiSecret().isEmpty());
+  EXPECT_EQ(false, measurementId().isEmpty());
+}

--- a/src/openstudio_lib/test/AnalyticsHelper_GTest.cpp
+++ b/src/openstudio_lib/test/AnalyticsHelper_GTest.cpp
@@ -37,6 +37,6 @@
 using namespace openstudio;
 
 TEST_F(OpenStudioLibFixture, AnalyticsHelperSecrets) {
-  EXPECT_EQ(false, apiSecret().isEmpty());
-  EXPECT_EQ(false, measurementId().isEmpty());
+  EXPECT_FALSE(apiSecret().isEmpty());
+  EXPECT_FALSE(measurementId().isEmpty());
 }

--- a/src/openstudio_lib/test/AnalyticsHelper_GTest.cpp
+++ b/src/openstudio_lib/test/AnalyticsHelper_GTest.cpp
@@ -34,7 +34,6 @@
 #include "../AnalyticsHelper.hpp"
 #include <AnalyticsHelperSecrets.hxx>
 
-
 using namespace openstudio;
 
 TEST_F(OpenStudioLibFixture, AnalyticsHelperSecrets) {


### PR DESCRIPTION
The current version of Google Analytics is being deprecated on July 1, 2023 so we want to update to Google Analytics 4 in our next release:

https://support.google.com/analytics/answer/11583528?hl=en