### PR TITLE
Remove ccache on Windows runners

### DIFF
--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -223,12 +223,9 @@ jobs:
 
           echo "Using chocolatey to install ninja"
           choco install ninja
-          choco list -lo --debug -v
-          which ccache
-          ls -alsh /c/ProgramData/chocolatey/bin/
-          rm -f "/c/ProgramData/Chocolatey/bin/ccache"
-          ls -alsh /c/ProgramData/chocolatey/bin/
-          which ccache
+
+          echo "Remove ccache if it exists"
+          rm -f "/c/ProgramData/Chocolatey/bin/ccache" || true
 
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
           MSVC_DIR=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -42,9 +42,50 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        #os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-12, macos-arm64]
-        os: [windows-2022]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-12, macos-arm64]
         include:
+        - os: ubuntu-20.04
+          allow_failure: true
+          SELF_HOSTED: false
+          PLATFORM_NAME: Linux
+          CPACK_BINARY_DEB: ON
+          CPACK_BINARY_IFW: OFF
+          CPACK_BINARY_TGZ: ON
+          CPACK_BINARY_ZIP: OFF
+          BINARY_EXT: deb
+          COMPRESSED_EXT: tar.gz
+          BINARY_PKG_PATH: _CPack_Packages/Linux/DEB
+          COMPRESSED_PKG_PATH: _CPack_Packages/Linux/TGZ
+          QT_OS_NAME: linux
+          QT_ARCH: gcc_64
+        - os: ubuntu-22.04
+          allow_failure: true
+          SELF_HOSTED: false
+          PLATFORM_NAME: Linux
+          CPACK_BINARY_DEB: ON
+          CPACK_BINARY_IFW: OFF
+          CPACK_BINARY_TGZ: ON
+          CPACK_BINARY_ZIP: OFF
+          BINARY_EXT: deb
+          COMPRESSED_EXT: tar.gz
+          BINARY_PKG_PATH: _CPack_Packages/Linux/DEB
+          COMPRESSED_PKG_PATH: _CPack_Packages/Linux/TGZ
+          QT_OS_NAME: linux
+          QT_ARCH: gcc_64
+        - os: windows-2019
+          allow_failure: false
+          SELF_HOSTED: false
+          PLATFORM_NAME: Windows
+          CPACK_BINARY_DEB: OFF
+          CPACK_BINARY_IFW: ON
+          CPACK_BINARY_TGZ: OFF
+          CPACK_BINARY_ZIP: ON
+          BINARY_EXT: exe
+          COMPRESSED_EXT: zip
+          BINARY_PKG_PATH: _CPack_Packages/win64/IFW
+          COMPRESSED_PKG_PATH: _CPack_Packages/win64/ZIP
+          QT_OS_NAME: windows
+          QT_ARCH: win64_msvc2019_64
         - os: windows-2022
           allow_failure: false
           SELF_HOSTED: false
@@ -59,6 +100,38 @@ jobs:
           COMPRESSED_PKG_PATH: _CPack_Packages/win64/ZIP
           QT_OS_NAME: windows
           QT_ARCH: win64_msvc2019_64
+        - os: macos-12
+          allow_failure: false
+          SELF_HOSTED: false
+          PLATFORM_NAME: Darwin
+          CPACK_BINARY_DEB: OFF
+          CPACK_BINARY_IFW: ON
+          CPACK_BINARY_TGZ: ON
+          CPACK_BINARY_ZIP: OFF
+          BINARY_EXT: dmg
+          COMPRESSED_EXT: tar.gz
+          BINARY_PKG_PATH: _CPack_Packages/Darwin/IFW
+          COMPRESSED_PKG_PATH: _CPack_Packages/Darwin/TGZ
+          MACOSX_DEPLOYMENT_TARGET: 10.15
+          SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+          QT_OS_NAME: mac
+          QT_ARCH: clang_64
+        - os: macos-arm64
+          allow_failure: false
+          SELF_HOSTED: true
+          PLATFORM_NAME: Darwin
+          CPACK_BINARY_DEB: OFF
+          CPACK_BINARY_IFW: ON
+          CPACK_BINARY_TGZ: ON
+          CPACK_BINARY_ZIP: OFF
+          BINARY_EXT: dmg
+          COMPRESSED_EXT: tar.gz
+          BINARY_PKG_PATH: _CPack_Packages/Darwin/IFW
+          COMPRESSED_PKG_PATH: _CPack_Packages/Darwin/TGZ
+          MACOSX_DEPLOYMENT_TARGET: 12.1
+          SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+          QT_OS_NAME: mac
+          QT_ARCH: arm_64
 
     steps:
     - uses: actions/checkout@v3
@@ -224,6 +297,9 @@ jobs:
           echo "Using chocolatey to install ninja"
           choco install ninja
 
+          # using ccache fails to build .rc files on Windows
+          # ccache is installed under chocolatey but `choco uninstall ccache` fails
+          # setting CCACHE_DISABLE=1 did not work, just remove ccache
           echo "Remove ccache if it exists"
           rm -f "/c/ProgramData/Chocolatey/bin/ccache" || true
 
@@ -484,10 +560,6 @@ jobs:
         echo "Using vcvarsall to initialize the development environment"
         call vcvarsall.bat x64
         dir
-        set
-        set CCACHE_DISABLE=1
-        where ccache
-        set
         cmake -G Ninja -DQT_INSTALL_DIR:PATH=${{ env.QT_INSTALL_DIR }} -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} ^
          -DBUILD_DOCUMENTATION:BOOL=${{ env.BUILD_DOCUMENTATION }} -DBUILD_TESTING:BOOL=${{ env.BUILD_TESTING }} -DBUILD_BENCHMARK:BOOL=${{ env.BUILD_BENCHMARK}} ^
          -DBUILD_PACKAGE:BOOL=${{ env.BUILD_PACKAGE }} -DCPACK_BINARY_DEB:BOOL=${{ env.CPACK_BINARY_DEB }} -DCPACK_BINARY_IFW:BOOL=${{ env.CPACK_BINARY_IFW }} ^
@@ -498,7 +570,6 @@ jobs:
          -DCPACK_SOURCE_TZ:BOOL=${{ env.CPACK_SOURCE_TZ }} -DCPACK_SOURCE_ZIP:BOOL=${{ env.CPACK_SOURCE_ZIP }} ^
          -DANALYTICS_API_SECRET:STRING=${{secrets.ANALYTICS_API_SECRET }} -DANALYTICS_MEASUREMENT_ID:STRING=${{secrets.ANALYTICS_MEASUREMENT_ID }} ^
          ../
-        set
         ninja
         ninja package
 

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -224,7 +224,10 @@ jobs:
           echo "Using chocolatey to install ninja"
           choco install ninja
           choco list -lo --debug -v
-          choco uninstall ccache
+          where ccache
+          del /F C:\ProgramData\chocolatey\bin\ccache.exe
+          where ccache
+
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
           MSVC_DIR=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)
           echo "Latest is: $MSVC_DIR"

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -223,6 +223,8 @@ jobs:
 
           echo "Using chocolatey to install ninja"
           choco install ninja
+          choco uninstall ccache
+          choco list --localonly
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
           MSVC_DIR=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)
           echo "Latest is: $MSVC_DIR"

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -225,14 +225,10 @@ jobs:
           choco install ninja
           choco list -lo --debug -v
           which ccache
-          ls -alsh /c/
           ls -alsh /c/ProgramData/chocolatey/bin/
-          where ccache
-          dir "C:/"
-          dir "C:/ProgramData/chocolatey/bin/"
-          ls -alsh /c/ProgramData/chocolatey/bin
-          rm -f "C:/ProgramData/chocolatey/bin/ccache.exe"
-          where ccache
+          rm -f "/c/ProgramData/Chocolatey/bin/ccache"
+          ls -alsh /c/ProgramData/chocolatey/bin/
+          which ccache
 
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
           MSVC_DIR=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -42,50 +42,9 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-12, macos-arm64]
+        #os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-12, macos-arm64]
+        os: [windows-2022]
         include:
-        - os: ubuntu-20.04
-          allow_failure: true
-          SELF_HOSTED: false
-          PLATFORM_NAME: Linux
-          CPACK_BINARY_DEB: ON
-          CPACK_BINARY_IFW: OFF
-          CPACK_BINARY_TGZ: ON
-          CPACK_BINARY_ZIP: OFF
-          BINARY_EXT: deb
-          COMPRESSED_EXT: tar.gz
-          BINARY_PKG_PATH: _CPack_Packages/Linux/DEB
-          COMPRESSED_PKG_PATH: _CPack_Packages/Linux/TGZ
-          QT_OS_NAME: linux
-          QT_ARCH: gcc_64
-        - os: ubuntu-22.04
-          allow_failure: true
-          SELF_HOSTED: false
-          PLATFORM_NAME: Linux
-          CPACK_BINARY_DEB: ON
-          CPACK_BINARY_IFW: OFF
-          CPACK_BINARY_TGZ: ON
-          CPACK_BINARY_ZIP: OFF
-          BINARY_EXT: deb
-          COMPRESSED_EXT: tar.gz
-          BINARY_PKG_PATH: _CPack_Packages/Linux/DEB
-          COMPRESSED_PKG_PATH: _CPack_Packages/Linux/TGZ
-          QT_OS_NAME: linux
-          QT_ARCH: gcc_64
-        - os: windows-2019
-          allow_failure: false
-          SELF_HOSTED: false
-          PLATFORM_NAME: Windows
-          CPACK_BINARY_DEB: OFF
-          CPACK_BINARY_IFW: ON
-          CPACK_BINARY_TGZ: OFF
-          CPACK_BINARY_ZIP: ON
-          BINARY_EXT: exe
-          COMPRESSED_EXT: zip
-          BINARY_PKG_PATH: _CPack_Packages/win64/IFW
-          COMPRESSED_PKG_PATH: _CPack_Packages/win64/ZIP
-          QT_OS_NAME: windows
-          QT_ARCH: win64_msvc2019_64
         - os: windows-2022
           allow_failure: false
           SELF_HOSTED: false
@@ -100,38 +59,6 @@ jobs:
           COMPRESSED_PKG_PATH: _CPack_Packages/win64/ZIP
           QT_OS_NAME: windows
           QT_ARCH: win64_msvc2019_64
-        - os: macos-12
-          allow_failure: false
-          SELF_HOSTED: false
-          PLATFORM_NAME: Darwin
-          CPACK_BINARY_DEB: OFF
-          CPACK_BINARY_IFW: ON
-          CPACK_BINARY_TGZ: ON
-          CPACK_BINARY_ZIP: OFF
-          BINARY_EXT: dmg
-          COMPRESSED_EXT: tar.gz
-          BINARY_PKG_PATH: _CPack_Packages/Darwin/IFW
-          COMPRESSED_PKG_PATH: _CPack_Packages/Darwin/TGZ
-          MACOSX_DEPLOYMENT_TARGET: 10.15
-          SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-          QT_OS_NAME: mac
-          QT_ARCH: clang_64
-        - os: macos-arm64
-          allow_failure: false
-          SELF_HOSTED: true
-          PLATFORM_NAME: Darwin
-          CPACK_BINARY_DEB: OFF
-          CPACK_BINARY_IFW: ON
-          CPACK_BINARY_TGZ: ON
-          CPACK_BINARY_ZIP: OFF
-          BINARY_EXT: dmg
-          COMPRESSED_EXT: tar.gz
-          BINARY_PKG_PATH: _CPack_Packages/Darwin/IFW
-          COMPRESSED_PKG_PATH: _CPack_Packages/Darwin/TGZ
-          MACOSX_DEPLOYMENT_TARGET: 12.1
-          SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
-          QT_OS_NAME: mac
-          QT_ARCH: arm_64
 
     steps:
     - uses: actions/checkout@v3
@@ -563,6 +490,7 @@ jobs:
          -DCPACK_SOURCE_TZ:BOOL=${{ env.CPACK_SOURCE_TZ }} -DCPACK_SOURCE_ZIP:BOOL=${{ env.CPACK_SOURCE_ZIP }} ^
          -DANALYTICS_API_SECRET:STRING=${{secrets.ANALYTICS_API_SECRET }} -DANALYTICS_MEASUREMENT_ID:STRING=${{secrets.ANALYTICS_MEASUREMENT_ID }} ^
          ../
+        set CCACHE_DISABLE=1
         ninja
         ninja package
 

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -224,8 +224,14 @@ jobs:
           echo "Using chocolatey to install ninja"
           choco install ninja
           choco list -lo --debug -v
+          which ccache
+          ls -alsh /c/
+          ls -alsh /c/ProgramData/chocolatey/bin/
           where ccache
-          rm -f C:/ProgramData/chocolatey/bin/ccache.exe
+          dir "C:/"
+          dir "C:/ProgramData/chocolatey/bin/"
+          ls -alsh /c/ProgramData/chocolatey/bin
+          rm -f "C:/ProgramData/chocolatey/bin/ccache.exe"
           where ccache
 
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -225,7 +225,7 @@ jobs:
           choco install ninja
           choco list -lo --debug -v
           where ccache
-          del /F C:\ProgramData\chocolatey\bin\ccache.exe
+          rm -f C:/ProgramData/chocolatey/bin/ccache.exe
           where ccache
 
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -223,6 +223,8 @@ jobs:
 
           echo "Using chocolatey to install ninja"
           choco install ninja
+          choco list -lo --debug -v
+          choco uninstall ccache
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
           MSVC_DIR=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)
           echo "Latest is: $MSVC_DIR"

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -480,6 +480,7 @@ jobs:
         echo "Using vcvarsall to initialize the development environment"
         call vcvarsall.bat x64
         dir
+        set CCACHE_DISABLE=1
         cmake -G Ninja -DQT_INSTALL_DIR:PATH=${{ env.QT_INSTALL_DIR }} -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} ^
          -DBUILD_DOCUMENTATION:BOOL=${{ env.BUILD_DOCUMENTATION }} -DBUILD_TESTING:BOOL=${{ env.BUILD_TESTING }} -DBUILD_BENCHMARK:BOOL=${{ env.BUILD_BENCHMARK}} ^
          -DBUILD_PACKAGE:BOOL=${{ env.BUILD_PACKAGE }} -DCPACK_BINARY_DEB:BOOL=${{ env.CPACK_BINARY_DEB }} -DCPACK_BINARY_IFW:BOOL=${{ env.CPACK_BINARY_IFW }} ^
@@ -490,7 +491,6 @@ jobs:
          -DCPACK_SOURCE_TZ:BOOL=${{ env.CPACK_SOURCE_TZ }} -DCPACK_SOURCE_ZIP:BOOL=${{ env.CPACK_SOURCE_ZIP }} ^
          -DANALYTICS_API_SECRET:STRING=${{secrets.ANALYTICS_API_SECRET }} -DANALYTICS_MEASUREMENT_ID:STRING=${{secrets.ANALYTICS_MEASUREMENT_ID }} ^
          ../
-        set CCACHE_DISABLE=1
         ninja
         ninja package
 

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -223,8 +223,6 @@ jobs:
 
           echo "Using chocolatey to install ninja"
           choco install ninja
-          choco uninstall ccache
-          choco list --localonly
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
           MSVC_DIR=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)
           echo "Latest is: $MSVC_DIR"
@@ -482,7 +480,10 @@ jobs:
         echo "Using vcvarsall to initialize the development environment"
         call vcvarsall.bat x64
         dir
+        set
         set CCACHE_DISABLE=1
+        where ccache
+        set
         cmake -G Ninja -DQT_INSTALL_DIR:PATH=${{ env.QT_INSTALL_DIR }} -DCMAKE_BUILD_TYPE:STRING=${{ env.BUILD_TYPE }} ^
          -DBUILD_DOCUMENTATION:BOOL=${{ env.BUILD_DOCUMENTATION }} -DBUILD_TESTING:BOOL=${{ env.BUILD_TESTING }} -DBUILD_BENCHMARK:BOOL=${{ env.BUILD_BENCHMARK}} ^
          -DBUILD_PACKAGE:BOOL=${{ env.BUILD_PACKAGE }} -DCPACK_BINARY_DEB:BOOL=${{ env.CPACK_BINARY_DEB }} -DCPACK_BINARY_IFW:BOOL=${{ env.CPACK_BINARY_IFW }} ^
@@ -493,6 +494,7 @@ jobs:
          -DCPACK_SOURCE_TZ:BOOL=${{ env.CPACK_SOURCE_TZ }} -DCPACK_SOURCE_ZIP:BOOL=${{ env.CPACK_SOURCE_ZIP }} ^
          -DANALYTICS_API_SECRET:STRING=${{secrets.ANALYTICS_API_SECRET }} -DANALYTICS_MEASUREMENT_ID:STRING=${{secrets.ANALYTICS_MEASUREMENT_ID }} ^
          ../
+        set
         ninja
         ninja package
 

--- a/src/openstudio_app/CMakeLists.txt
+++ b/src/openstudio_app/CMakeLists.txt
@@ -46,7 +46,9 @@ qt6_wrap_cpp(${target_name}_moc_src ${${target_name}_moc})
 CONFIGURE_FILE_WITH_CHECKSUM(AboutBox.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/AboutBox.hpp")
 
 set(OPENSTUDIOAPPLICATION_ICON_FOLDER "${PROJECT_SOURCE_DIR}/icons")
+message("Creating OpenStudioApp.rc")
 if(WIN32)
+  message("Removing bigobj")
   remove_definitions(/bigobj)
   CONFIGURE_FILE_WITH_CHECKSUM(OpenStudioApp.rc.in "${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp.rc")
   set(ICON_SRC "${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp.rc")
@@ -117,6 +119,13 @@ elseif(UNIX)
     #)
   #endforeach()
 
+endif()
+
+message("ICON_SRC = ${ICON_SRC}")
+if(EXISTS "${ICON_SRC}")
+   message("ICON_SRC exists")
+else()
+   message("ICON_SRC does not exists")
 endif()
 
 add_executable(${target_name}

--- a/src/openstudio_app/CMakeLists.txt
+++ b/src/openstudio_app/CMakeLists.txt
@@ -144,6 +144,8 @@ endif()
 if(WIN32)
   # increase stack size
   target_link_options(${target_name} PRIVATE /STACK:8388608)
+  # ccache doesn't work with .rc files on windows
+  set_target_properties(${target_name} PROPERTIES CXX_COMPILER_LAUNCHER "")
 endif()
 
 # This is because Apple has app bundles for .apps.

--- a/src/openstudio_app/CMakeLists.txt
+++ b/src/openstudio_app/CMakeLists.txt
@@ -46,9 +46,7 @@ qt6_wrap_cpp(${target_name}_moc_src ${${target_name}_moc})
 CONFIGURE_FILE_WITH_CHECKSUM(AboutBox.hpp.in "${CMAKE_CURRENT_BINARY_DIR}/AboutBox.hpp")
 
 set(OPENSTUDIOAPPLICATION_ICON_FOLDER "${PROJECT_SOURCE_DIR}/icons")
-message("Creating OpenStudioApp.rc")
 if(WIN32)
-  message("Removing bigobj")
   remove_definitions(/bigobj)
   CONFIGURE_FILE_WITH_CHECKSUM(OpenStudioApp.rc.in "${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp.rc")
   set(ICON_SRC "${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApp.rc")
@@ -121,13 +119,6 @@ elseif(UNIX)
 
 endif()
 
-message("ICON_SRC = ${ICON_SRC}")
-if(EXISTS "${ICON_SRC}")
-   message("ICON_SRC exists")
-else()
-   message("ICON_SRC does not exists")
-endif()
-
 add_executable(${target_name}
   WIN32
   MACOSX_BUNDLE
@@ -144,8 +135,6 @@ endif()
 if(WIN32)
   # increase stack size
   target_link_options(${target_name} PRIVATE /STACK:8388608)
-  # ccache doesn't work with .rc files on windows
-  set_target_properties(${target_name} PROPERTIES CXX_COMPILER_LAUNCHER "")
 endif()
 
 # This is because Apple has app bundles for .apps.


### PR DESCRIPTION
ccache is causing the .rc file build to fail, ccache is installed in the chocolatey folder on windows-2022 runner but is not a proper choco package

Setting the CCACHE_DISABLE=1 environment variable or setting CXX_COMPILER_LAUNCHER="" on the OpenStudioApplication target did not work 

Just delete ccache since it won't help us much on the runner