### PR TITLE
Add search bar to OSCollapsibleItemList

### DIFF
--- a/src/openstudio_lib/ApplyMeasureNowDialog.hpp
+++ b/src/openstudio_lib/ApplyMeasureNowDialog.hpp
@@ -32,7 +32,6 @@
 
 #include "../shared_gui_components/HeaderViews.hpp"
 #include "../shared_gui_components/OSDialog.hpp"
-#include "../shared_gui_components/OSListView.hpp"
 
 #include <openstudio/model/Model.hpp>
 

--- a/src/openstudio_lib/OSCollapsibleItemList.cpp
+++ b/src/openstudio_lib/OSCollapsibleItemList.cpp
@@ -178,7 +178,7 @@ void OSCollapsibleItemList::onCollapsableItemSelected(OSCollapsibleItem* selecte
     collapsibleItem = qobject_cast<OSCollapsibleItem*>(widget);
     if (collapsibleItem) {
       if (collapsibleItem == selectedItem) {
-  
+
         if (m_selectedCollapsibleItem != collapsibleItem) {
           // no need to select collapsibleItem since it is already selected
           // expand collapsable item and select first item inside
@@ -249,7 +249,7 @@ void OSCollapsibleItemList::onSearchTextEdited(const QString& text) {
     if (collapsibleItem) {
       std::vector<OSItem*> items = collapsibleItem->itemList()->items();
       unsigned numVisible = 0;
-      for (const auto& item: items ) {
+      for (const auto& item : items) {
         if (m_searchActive) {
           if (item->text().contains(text, Qt::CaseInsensitive)) {
             item->setVisible(true);
@@ -258,7 +258,7 @@ void OSCollapsibleItemList::onSearchTextEdited(const QString& text) {
               collapsibleItem->itemList()->selectItem(newSelectedItem);
             }
             ++numVisible;
-          }else{
+          } else {
             item->setVisible(false);
           }
         } else {
@@ -269,11 +269,10 @@ void OSCollapsibleItemList::onSearchTextEdited(const QString& text) {
 
       if (!m_searchActive) {
         collapsibleItem->setExpanded(collapsibleItem->isSelected());
-      }else{
+      } else {
         collapsibleItem->setExpanded(numVisible > 0);
-      }      
+      }
     }
-
   }
 }
 

--- a/src/openstudio_lib/OSCollapsibleItemList.cpp
+++ b/src/openstudio_lib/OSCollapsibleItemList.cpp
@@ -62,6 +62,7 @@ OSCollapsibleItemList::OSCollapsibleItemList(bool addScrollArea, QWidget* parent
   this->setLayout(outerVLayout);
 
   m_searchBox = new QLineEdit();
+  m_searchBox->setClearButtonEnabled(true);
   outerVLayout->addWidget(m_searchBox);
   connect(m_searchBox, &QLineEdit::textEdited, this, &OSCollapsibleItemList::onSearchTextEdited);
 
@@ -235,17 +236,15 @@ void OSCollapsibleItemList::onItemSelected(OSItem* item) {
 }
 
 void OSCollapsibleItemList::onSearchTextEdited(const QString& text) {
-  QLayoutItem* layoutItem = nullptr;
-  OSCollapsibleItem* collapsibleItem = nullptr;
-  OSItem* newSelectedItem = nullptr;
   m_searchActive = !text.isEmpty();
 
+  OSItem* newSelectedItem = nullptr;
   for (int i = 0; i < m_vLayout->count(); ++i) {
 
-    layoutItem = m_vLayout->itemAt(i);
+    QLayoutItem* layoutItem = m_vLayout->itemAt(i);
     QWidget* widget = layoutItem->widget();
 
-    collapsibleItem = qobject_cast<OSCollapsibleItem*>(widget);
+    OSCollapsibleItem* collapsibleItem = qobject_cast<OSCollapsibleItem*>(widget);
     if (collapsibleItem) {
       std::vector<OSItem*> items = collapsibleItem->itemList()->items();
       unsigned numVisible = 0;
@@ -269,8 +268,10 @@ void OSCollapsibleItemList::onSearchTextEdited(const QString& text) {
 
       if (!m_searchActive) {
         collapsibleItem->setExpanded(collapsibleItem->isSelected());
+        collapsibleItem->setVisible(true);
       } else {
         collapsibleItem->setExpanded(numVisible > 0);
+        collapsibleItem->setVisible(numVisible > 0);
       }
     }
   }

--- a/src/openstudio_lib/OSCollapsibleItemList.hpp
+++ b/src/openstudio_lib/OSCollapsibleItemList.hpp
@@ -35,6 +35,7 @@
 
 class QVBoxLayout;
 class QHBoxLayout;
+class QLineEdit;
 
 namespace openstudio {
 
@@ -77,14 +78,18 @@ class OSCollapsibleItemList : public OSItemSelector
 
   void onItemSelected(OSItem* item);
 
+  void onSearchTextEdited(const QString& text);
+
  protected:
   void paintEvent(QPaintEvent* event) override;
 
  private:
   QVBoxLayout* m_vLayout;
+  QLineEdit* m_searchBox;
   QHBoxLayout* m_contentLayout;
   OSCollapsibleItem* m_selectedCollapsibleItem;
   std::vector<OSCollapsibleItem*> m_collapsibleItems;
+  bool m_searchActive;
   bool m_itemsDraggable;
   bool m_itemsRemoveable;
   OSItemType m_itemsType;

--- a/src/openstudio_lib/RefrigerationGraphicsItems.hpp
+++ b/src/openstudio_lib/RefrigerationGraphicsItems.hpp
@@ -34,7 +34,6 @@
 #include "OSItem.hpp"
 #include "OSDropZone.hpp"
 #include "../shared_gui_components/OSListController.hpp"
-#include "../shared_gui_components/OSListView.hpp"
 #include "../shared_gui_components/GraphicsItems.hpp"
 #include <openstudio/utilities/idf/Handle.hpp>
 

--- a/src/openstudio_lib/VRFGraphicsItems.hpp
+++ b/src/openstudio_lib/VRFGraphicsItems.hpp
@@ -34,7 +34,6 @@
 #include "OSItem.hpp"
 #include "OSDropZone.hpp"
 #include "../shared_gui_components/OSListController.hpp"
-#include "../shared_gui_components/OSListView.hpp"
 #include "../shared_gui_components/GraphicsItems.hpp"
 
 class QGraphicsView;


### PR DESCRIPTION
Adds a search bar to OSCollapsibleItemList used for most of the library tabs.  OSListView which is used by the ScriptsTab is considerably different, so I did not add a search feature there for now.