### PR TITLE
New Geometry Diagnostics in the Geometry Preview: Detect incorrectly oriented surfaces in spaces, non convex spaces

### DIFF
--- a/src/openstudio_lib/GeometryPreviewView.cpp
+++ b/src/openstudio_lib/GeometryPreviewView.cpp
@@ -30,6 +30,7 @@
 #include "GeometryPreviewView.hpp"
 #include "OSAppBase.hpp"
 #include "OSDocument.hpp"
+#include "MainWindow.hpp"
 
 #include "../model_editor/Application.hpp"
 
@@ -46,6 +47,7 @@
 #include <QFile>
 #include <QWebEngineScriptCollection>
 #include <QtConcurrent>
+#include <QCheckBox>
 
 using namespace std::placeholders;
 
@@ -99,6 +101,26 @@ PreviewWebView::PreviewWebView(bool isIP, const model::Model& model, QWidget* t_
   m_page = new OSWebEnginePage(m_view);
   m_view->setPage(m_page);  // note, view does not take ownership of page
 
+  auto* mainWindow = OSAppBase::instance()->currentDocument()->mainWindow();
+  const bool verboseOutput = mainWindow->geometryDiagnostics();
+  m_geometryDiagnosticsBox = new QCheckBox();
+  m_geometryDiagnosticsBox->setText("Geometry Diagnostics");
+  m_geometryDiagnosticsBox->setChecked(verboseOutput);
+  m_geometryDiagnosticsBox->setToolTip("Enables checks for Surface/Space Convexity. The ThreeJS export is slightly slower");
+  connect(m_geometryDiagnosticsBox, &QCheckBox::clicked, mainWindow, &MainWindow::toggleGeometryDiagnostics);
+  connect(m_geometryDiagnosticsBox, &QCheckBox::stateChanged, [this](int state) {
+    if (state == Qt::Checked && !m_includeGeometryDiagnostics) {
+      // Old m_json didn't contain the geometry diagnostics, so we need to include it, so we should set m_json to empty so the
+      // ThreeJSForwardTranslator is called again
+      m_json = QString();
+    } else {
+      // Any other case, the former m_json includes diagnostics, we only trigger the refresh which will reanimate the web page and potentially turn
+      // off the Geometry diags datGUI
+    }
+    refreshClicked();
+  });
+  hLayout->addWidget(m_geometryDiagnosticsBox, 0, Qt::AlignVCenter);
+
   connect(m_view, &QWebEngineView::loadFinished, this, &PreviewWebView::onLoadFinished);
   connect(m_view, &QWebEngineView::renderProcessTerminated, this, &PreviewWebView::onRenderProcessTerminated);
 
@@ -127,6 +149,8 @@ PreviewWebView::PreviewWebView(bool isIP, const model::Model& model, QWidget* t_
 PreviewWebView::~PreviewWebView() = default;
 
 void PreviewWebView::refreshClicked() {
+  // qDebug() << "refreshClicked";
+
   m_progressBar->setError(false);
 
   m_view->triggerPageAction(QWebEnginePage::ReloadAndBypassCache);
@@ -156,9 +180,13 @@ void PreviewWebView::onLoadFinished(bool ok) {
     std::function<void(double)> updatePercentage = std::bind(&PreviewWebView::onTranslateProgress, this, _1);
     //ThreeScene scene = modelToThreeJS(m_model.clone(true).cast<model::Model>(), true, updatePercentage); // triangulated
 
+    // qDebug() << "ThreeJSForwardTranslator";
+
     model::ThreeJSForwardTranslator ft;
-    ThreeScene scene = ft.modelToThreeJS(m_model, true, updatePercentage);  // triangulated
-    std::string json = scene.toJSON(false);                                 // no pretty print
+    m_includeGeometryDiagnostics = m_geometryDiagnosticsBox->isChecked();
+    ft.setIncludeGeometryDiagnostics(m_includeGeometryDiagnostics);
+    const ThreeScene scene = ft.modelToThreeJS(m_model, true, updatePercentage);  // triangulated
+    const std::string json = scene.toJSON(false);                                 // no pretty print
     m_json = QString::fromStdString(json);
   } else {
     m_progressBar->setValue(90);
@@ -168,7 +196,8 @@ void PreviewWebView::onLoadFinished(bool ok) {
   m_document->disable();
 
   // call init and animate
-  QString javascript = QString("init(") + m_json + QString(");\n animate();\n initDatGui();");
+  const QString javascript =
+    QString("init(%1, %2);\n animate();\n initDatGui();").arg(m_json, m_geometryDiagnosticsBox->isChecked() ? "true" : "false");
   m_view->page()->runJavaScript(javascript, [this](const QVariant& v) { onJavaScriptFinished(v); });
 
   //javascript = QString("os_data.metadata.version");

--- a/src/openstudio_lib/GeometryPreviewView.hpp
+++ b/src/openstudio_lib/GeometryPreviewView.hpp
@@ -41,6 +41,7 @@
 #include <QWidget>
 #include <QWebEngineView>
 
+class QCheckBox;
 class QComboBox;
 class QPushButton;
 
@@ -91,6 +92,8 @@ class PreviewWebView : public QWidget
   model::Model m_model;
 
   ProgressBarWithError* m_progressBar;
+  QCheckBox* m_geometryDiagnosticsBox;
+  bool m_includeGeometryDiagnostics;
   QPushButton* m_refreshBtn;
 
   QWebEngineView* m_view;

--- a/src/openstudio_lib/MainWindow.cpp
+++ b/src/openstudio_lib/MainWindow.cpp
@@ -279,6 +279,7 @@ void MainWindow::readSettings() {
   restoreState(settings.value("state").toByteArray());
   m_displayIP = settings.value("displayIP").toBool();
   m_verboseOutput = settings.value("verboseOutput").toBool();
+  m_geometryDiagnostics = settings.value("geometryDiagnostics").toBool();
   m_currLang = settings.value("language", "en").toString();
   LOG_FREE(Debug, "MainWindow", "\n\n\nm_currLang=[" << m_currLang.toStdString() << "]\n\n\n");
   if (m_currLang.isEmpty()) {
@@ -297,6 +298,7 @@ void MainWindow::writeSettings() {
   settings.setValue("state", saveState());
   settings.setValue("displayIP", m_displayIP);
   settings.setValue("verboseOutput", m_verboseOutput);
+  settings.setValue("geometryDiagnostics", m_geometryDiagnostics);
   settings.setValue("language", m_currLang);
   settings.setValue("analyticsId", m_analyticsId);
 }
@@ -319,6 +321,10 @@ void MainWindow::toggleUnits(bool displayIP) {
 
 bool MainWindow::verboseOutput() const {
   return m_verboseOutput;
+}
+
+bool MainWindow::geometryDiagnostics() const {
+  return m_geometryDiagnostics;
 }
 
 void MainWindow::onVerticalTabSelected(int verticalTabId) {
@@ -381,6 +387,10 @@ void MainWindow::onVerticalTabSelected(int verticalTabId) {
 
 void MainWindow::toggleVerboseOutput(bool verboseOutput) {
   m_verboseOutput = verboseOutput;
+}
+
+void MainWindow::toggleGeometryDiagnostics(bool geometryDiagnostics) {
+  m_geometryDiagnostics = geometryDiagnostics;
 }
 
 void MainWindow::promptAnalytics() {

--- a/src/openstudio_lib/MainWindow.hpp
+++ b/src/openstudio_lib/MainWindow.hpp
@@ -87,6 +87,8 @@ class MainWindow : public QMainWindow
 
   void enableComponentsMeasuresActions(bool enable);
 
+  bool geometryDiagnostics() const;
+
   QString lastPath() const;
 
   VerticalTabWidget* verticalTabWidget() {
@@ -181,6 +183,8 @@ class MainWindow : public QMainWindow
 
   void toggleVerboseOutput(bool verboseOutput);
 
+  void toggleGeometryDiagnostics(bool geometryDiagnostics);
+
   void promptAnalytics();
 
   void toggleAnalytics(bool allowAnalytics);
@@ -214,6 +218,8 @@ class MainWindow : public QMainWindow
   bool m_displayIP;
 
   bool m_verboseOutput = false;
+
+  bool m_geometryDiagnostics = false;
 
   QString m_currLang;
 

--- a/src/openstudio_lib/library/geometry_preview.html
+++ b/src/openstudio_lib/library/geometry_preview.html
@@ -1839,6 +1839,7 @@ c);e.bind(this.domElement,"transitionend",c);e.bind(this.domElement,"oTransition
 
 // global variable, set in init
 var os_data;
+var includeGeometryDiagnostics;
 
 
 var renderer, scene, light, scene_objects, scene_edges, object_edges, coincident_objects, back_objects, dot_points;
@@ -2200,10 +2201,11 @@ function setCameraAngles(camera, controls, theta, phi, tweenTime) {
   });
 }
 
-function init(os_data_in) {
+function init(os_data_in, includeGeometryDiagnostics_in) {
 
   // set global variable
   os_data = os_data_in;
+  includeGeometryDiagnostics = includeGeometryDiagnostics_in;
 
   var css = document.head.appendChild(document.createElement('style'));
   css.innerHTML = 'body { font:600 12pt monospace; margin:0; overflow:hidden; }';
@@ -2549,6 +2551,10 @@ function onDocumentMouseClick(event) {
   }
 }
 
+function colorize_bool(b) {
+  return "<span style='color: " + (b ? 'green' : 'red') + ";'>" + b + '</span>'
+}
+
 function displaySelectedObjectDetails() {
 
   headsUp.style.left = 10 + 0.5 * window.innerWidth + mouse.x * 0.5 * window.innerWidth + 'px';
@@ -2568,10 +2574,12 @@ function displaySelectedObjectDetails() {
         if (inter.userData.spaceName){
           txt += 'Space Name: ' + inter.userData.spaceName;
         }
-        txt += 'Convex' + inter.userData.convex;
-        txt += 'CorrectlyOriented' + inter.userData.correctlyOriented;
-        txt += 'Space Convex: ' + inter.userData.spaceConvex;
-        txt += 'Space Enclosed: ' + inter.userData.spaceEnclosed;
+        if (includeGeometryDiagnostics) {
+          txt += '<br> Convex: ' + colorize_bool(inter.userData.convex);
+          txt += '<br> CorrectlyOriented: ' + colorize_bool(inter.userData.correctlyOriented);
+          txt += '<br> Space Convex: ' + colorize_bool(inter.userData.spaceConvex);
+          txt += '<br> Space Enclosed: ' + colorize_bool(inter.userData.spaceEnclosed);
+        }
         break;
       case "Normal":
         txt += 'Surface Type: ' + inter.userData.surfaceType + '<br>'
@@ -2884,17 +2892,19 @@ var update = function (value) {
       object.visible = adjacencyIssueIds.has(object.id);
     }
 
-    if (settings.showOnlyNonConvexSurfaces && object.userData.convex) {
-      object.visible = false;
-    }
-    if (settings.showOnlyNonConvexSpaces && object.userData.spaceConvex) {
-      object.visible = false;
-    }
-    if (settings.showOnlyNonEnclosedSpaces && object.userData.spaceEnclosed) {
-      object.visible = false;
-    }
-    if (settings.showOnlyIncorrectlyOrientedSurfaces && object.userData.correctlyOriented) {
-      object.visible = false;
+    if (includeGeometryDiagnostics) {
+      if (settings.showOnlyNonConvexSurfaces && object.userData.convex) {
+        object.visible = false;
+      }
+      if (settings.showOnlyNonConvexSpaces && object.userData.spaceConvex) {
+        object.visible = false;
+      }
+      if (settings.showOnlyNonEnclosedSpaces && object.userData.spaceEnclosed) {
+        object.visible = false;
+      }
+      if (settings.showOnlyIncorrectlyOrientedSurfaces && object.userData.correctlyOriented) {
+        object.visible = false;
+      }
     }
 
     if (settings.showStory !== 'All Stories' && settings.showStory !== object.userData.buildingStoryName) {
@@ -3222,34 +3232,36 @@ var initDatGui = function () {
     adjacencies.open();
   }
 
-  {
-    var surfaceLevelIssues =  diagnostics.addFolder('Surface Level Issues')
-    surfaceLevelIssues.add(settings, 'showOnlyNonConvexSurfaces').name('Non-Convex Surfaces Only').onChange(value => {
-        removeSelection();
-        setLocalStorage('showOnlyNonConvexSurfaces', value);
-        update(value);
-    });
-    surfaceLevelIssues.add(settings, 'showOnlyIncorrectlyOrientedSurfaces').name('Incorrectly Oriented Surfaces Only').onChange(value => {
-        removeSelection();
-        setLocalStorage('showOnlyIncorrectlyOrientedSurfaces', value);
-        update(value);
-    });
-    surfaceLevelIssues.open();
-  }
-  {
-    var spaceLevelIssues =  diagnostics.addFolder('Space Level Issues')
-    spaceLevelIssues.add(settings, 'showOnlyNonConvexSpaces').name('Non-Convex Spaces Only').onChange(value => {
-        removeSelection();
-        setLocalStorage('showOnlyNonConvexSpaces', value);
-        update(value);
-    });
+  if(includeGeometryDiagnostics) {
+    {
+      var surfaceLevelIssues =  diagnostics.addFolder('Surface Level Issues')
+      surfaceLevelIssues.add(settings, 'showOnlyNonConvexSurfaces').name('Non-Convex Surfaces Only').onChange(value => {
+          removeSelection();
+          setLocalStorage('showOnlyNonConvexSurfaces', value);
+          update(value);
+      });
+      surfaceLevelIssues.add(settings, 'showOnlyIncorrectlyOrientedSurfaces').name('Incorrectly Oriented Surfaces Only').onChange(value => {
+          removeSelection();
+          setLocalStorage('showOnlyIncorrectlyOrientedSurfaces', value);
+          update(value);
+      });
+      surfaceLevelIssues.open();
+    }
+    {
+      var spaceLevelIssues =  diagnostics.addFolder('Space Level Issues')
+      spaceLevelIssues.add(settings, 'showOnlyNonConvexSpaces').name('Non-Convex Spaces Only').onChange(value => {
+          removeSelection();
+          setLocalStorage('showOnlyNonConvexSpaces', value);
+          update(value);
+      });
 
-    spaceLevelIssues.add(settings, 'showOnlyNonEnclosedSpaces').name('Non-Enclosed Spaces Only').onChange(value => {
-        removeSelection();
-        setLocalStorage('showOnlyNonEnclosedSpaces', value);
-        update(value);
-    });
-    spaceLevelIssues.open();
+      spaceLevelIssues.add(settings, 'showOnlyNonEnclosedSpaces').name('Non-Enclosed Spaces Only').onChange(value => {
+          removeSelection();
+          setLocalStorage('showOnlyNonEnclosedSpaces', value);
+          update(value);
+      });
+      spaceLevelIssues.open();
+    }
   }
   diagnostics.open();
 

--- a/src/openstudio_lib/library/geometry_preview.html
+++ b/src/openstudio_lib/library/geometry_preview.html
@@ -1905,8 +1905,12 @@ var settings = {
   renderBy: 'Surface Type',
   showStory: 'All Stories',
   showAirLoop: 'All Loops',
-  findAdjacencyIssues: false,
-  findAdjacencyThreshold: 1,
+  findAdjacencyIssues: getBoolFromLocalStorage('findAdjacencyIssues', false),
+  findAdjacencyThreshold: getFloatFromLocalStorage('findAdjacencyThreshold', 1),
+  showOnlyNonConvexSurfaces: getBoolFromLocalStorage('showOnlyNonConvexSurfaces', false),
+  showOnlyNonConvexSpaces: getBoolFromLocalStorage('showOnlyNonConvexSpaces', false),
+  showOnlyNonEnclosedSpaces: getBoolFromLocalStorage('showOnlyNonEnclosedSpaces', false),
+  showOnlyIncorrectlyOrientedSurfaces: getBoolFromLocalStorage('showOnlyIncorrectlyOrientedSurfaces', false),
   searchType: getStringFromLocalStorage('searchType', 'Surfaces'),
   searchName: getStringFromLocalStorage('searchName', ''),
   showFloors: getBoolFromLocalStorage('showFloors', true),
@@ -2564,6 +2568,10 @@ function displaySelectedObjectDetails() {
         if (inter.userData.spaceName){
           txt += 'Space Name: ' + inter.userData.spaceName;
         }
+        txt += 'Convex' + inter.userData.convex;
+        txt += 'CorrectlyOriented' + inter.userData.correctlyOriented;
+        txt += 'Space Convex: ' + inter.userData.spaceConvex;
+        txt += 'Space Enclosed: ' + inter.userData.spaceEnclosed;
         break;
       case "Normal":
         txt += 'Surface Type: ' + inter.userData.surfaceType + '<br>'
@@ -2876,6 +2884,19 @@ var update = function (value) {
       object.visible = adjacencyIssueIds.has(object.id);
     }
 
+    if (settings.showOnlyNonConvexSurfaces && object.userData.convex) {
+      object.visible = false;
+    }
+    if (settings.showOnlyNonConvexSpaces && object.userData.spaceConvex) {
+      object.visible = false;
+    }
+    if (settings.showOnlyNonEnclosedSpaces && object.userData.spaceEnclosed) {
+      object.visible = false;
+    }
+    if (settings.showOnlyIncorrectlyOrientedSurfaces && object.userData.correctlyOriented) {
+      object.visible = false;
+    }
+
     if (settings.showStory !== 'All Stories' && settings.showStory !== object.userData.buildingStoryName) {
       object.visible = false;
     }
@@ -3181,22 +3202,56 @@ var initDatGui = function () {
   });
   f1.open();
 
-  var f2 = gui.addFolder('Potential Adjacency Issues');
-  f2.add(settings, 'findAdjacencyIssues').name('Enable').onChange(value => {
-      removeSelection();
-      setLocalStorage('findAdjacencyThreshold', value);
-      updateAdjacencyIssues();
-      update(value);
-  });
-  f2.add(settings, 'findAdjacencyThreshold', 0.1, 10, 0.5).name('Threshold').onFinishChange(function (value) {
-      if (settings.findAdjacencyIssues) {
-          removeSelection();
-          setLocalStorage('findAdjacencyThreshold', value);
-          updateAdjacencyIssues();
-          update(value);
-      }
-  });
-  f2.open();
+  var diagnostics = gui.addFolder("Diagnostic Tools")
+  {
+    var adjacencies = diagnostics.addFolder('Potential Adjacency Issues');
+    adjacencies.add(settings, 'findAdjacencyIssues').name('Enable').onChange(value => {
+        removeSelection();
+        setLocalStorage('findAdjacencyIssues', value);
+        updateAdjacencyIssues();
+        update(value);
+    });
+    adjacencies.add(settings, 'findAdjacencyThreshold', 0.1, 10, 0.5).name('Threshold').onFinishChange(function (value) {
+        if (settings.findAdjacencyIssues) {
+            removeSelection();
+            setLocalStorage('findAdjacencyThreshold', value);
+            updateAdjacencyIssues();
+            update(value);
+        }
+    });
+    adjacencies.open();
+  }
+
+  {
+    var surfaceLevelIssues =  diagnostics.addFolder('Surface Level Issues')
+    surfaceLevelIssues.add(settings, 'showOnlyNonConvexSurfaces').name('Non-Convex Surfaces Only').onChange(value => {
+        removeSelection();
+        setLocalStorage('showOnlyNonConvexSurfaces', value);
+        update(value);
+    });
+    surfaceLevelIssues.add(settings, 'showOnlyIncorrectlyOrientedSurfaces').name('Incorrectly Oriented Surfaces Only').onChange(value => {
+        removeSelection();
+        setLocalStorage('showOnlyIncorrectlyOrientedSurfaces', value);
+        update(value);
+    });
+    surfaceLevelIssues.open();
+  }
+  {
+    var spaceLevelIssues =  diagnostics.addFolder('Space Level Issues')
+    spaceLevelIssues.add(settings, 'showOnlyNonConvexSpaces').name('Non-Convex Spaces Only').onChange(value => {
+        removeSelection();
+        setLocalStorage('showOnlyNonConvexSpaces', value);
+        update(value);
+    });
+
+    spaceLevelIssues.add(settings, 'showOnlyNonEnclosedSpaces').name('Non-Enclosed Spaces Only').onChange(value => {
+        removeSelection();
+        setLocalStorage('showOnlyNonEnclosedSpaces', value);
+        update(value);
+    });
+    spaceLevelIssues.open();
+  }
+  diagnostics.open();
 
   var f3 = gui.addFolder('Camera');
   [


### PR DESCRIPTION
Opt-in feature to enable the geometry diagnostics from this PR:

* https://github.com/NREL/OpenStudio/pull/4843

![Convexity](https://github.com/openstudiocoalition/OpenStudioApplication/assets/5479063/601e32d7-a07c-48b5-8c6b-5e5c2e16f2e9)

# TODO:

* Having trouble tweaking the display of the dat GUI menu so that the labels won't be truncated as much.
    * The stylesheet is inlined in dat GUI. This can be seen here in the geometry_refactor branch: https://github.com/openstudiocoalition/OpenStudioApplication/blob/4d89d8bcba5bac67c519b00eb75aad76f6ac743a/src/openstudio_lib/library/js/dat.gui.0.7.9.js#L1673
* Not sure if I should build upon #628 or not. So I have two separate branches (one with 628, one without (this one))   
    *  if #628 is merged first, then should change the feature branch to `geometry_diagnostics_with_refactor`, see  https://github.com/openstudiocoalition/OpenStudioApplication/compare/geometry_refactor...geometry_diagnostics_with_refactor?expand=1
