### PR TITLE
New Geometry Diagnostics in the Geometry Preview: Detect incorrectly oriented surfaces in spaces, non convex spaces

### DIFF
--- a/src/openstudio_lib/GeometryPreviewView.cpp
+++ b/src/openstudio_lib/GeometryPreviewView.cpp
@@ -106,7 +106,8 @@ PreviewWebView::PreviewWebView(bool isIP, const model::Model& model, QWidget* t_
   m_geometryDiagnosticsBox = new QCheckBox();
   m_geometryDiagnosticsBox->setText("Geometry Diagnostics");
   m_geometryDiagnosticsBox->setChecked(verboseOutput);
-  m_geometryDiagnosticsBox->setToolTip("Enables checks for Surface/Space Convexity. The ThreeJS export is slightly slower");
+  m_geometryDiagnosticsBox->setToolTip(
+    "Enables adjacency issues. Enables checks for Surface/Space Convexity, due to this the ThreeJS export is slightly slower");
   connect(m_geometryDiagnosticsBox, &QCheckBox::clicked, mainWindow, &MainWindow::toggleGeometryDiagnostics);
   connect(m_geometryDiagnosticsBox, &QCheckBox::stateChanged, [this](int state) {
     if (state == Qt::Checked && !m_includeGeometryDiagnostics) {

--- a/src/openstudio_lib/GeometryPreviewView.hpp
+++ b/src/openstudio_lib/GeometryPreviewView.hpp
@@ -41,6 +41,7 @@
 #include <QWidget>
 #include <QWebEngineView>
 
+class QCheckBox;
 class QComboBox;
 class QPushButton;
 
@@ -91,6 +92,8 @@ class PreviewWebView : public QWidget
   model::Model m_model;
 
   ProgressBarWithError* m_progressBar;
+  QCheckBox* m_geometryDiagnosticsBox;
+  bool m_includeGeometryDiagnostics;
   QPushButton* m_refreshBtn;
 
   QWebEngineView* m_view;

--- a/src/openstudio_lib/MainWindow.cpp
+++ b/src/openstudio_lib/MainWindow.cpp
@@ -279,6 +279,7 @@ void MainWindow::readSettings() {
   restoreState(settings.value("state").toByteArray());
   m_displayIP = settings.value("displayIP").toBool();
   m_verboseOutput = settings.value("verboseOutput").toBool();
+  m_geometryDiagnostics = settings.value("geometryDiagnostics").toBool();
   m_currLang = settings.value("language", "en").toString();
   LOG_FREE(Debug, "MainWindow", "\n\n\nm_currLang=[" << m_currLang.toStdString() << "]\n\n\n");
   if (m_currLang.isEmpty()) {
@@ -297,6 +298,7 @@ void MainWindow::writeSettings() {
   settings.setValue("state", saveState());
   settings.setValue("displayIP", m_displayIP);
   settings.setValue("verboseOutput", m_verboseOutput);
+  settings.setValue("geometryDiagnostics", m_geometryDiagnostics);
   settings.setValue("language", m_currLang);
   settings.setValue("analyticsId", m_analyticsId);
 }
@@ -319,6 +321,10 @@ void MainWindow::toggleUnits(bool displayIP) {
 
 bool MainWindow::verboseOutput() const {
   return m_verboseOutput;
+}
+
+bool MainWindow::geometryDiagnostics() const {
+  return m_geometryDiagnostics;
 }
 
 void MainWindow::onVerticalTabSelected(int verticalTabId) {
@@ -381,6 +387,10 @@ void MainWindow::onVerticalTabSelected(int verticalTabId) {
 
 void MainWindow::toggleVerboseOutput(bool verboseOutput) {
   m_verboseOutput = verboseOutput;
+}
+
+void MainWindow::toggleGeometryDiagnostics(bool geometryDiagnostics) {
+  m_geometryDiagnostics = geometryDiagnostics;
 }
 
 void MainWindow::promptAnalytics() {

--- a/src/openstudio_lib/MainWindow.hpp
+++ b/src/openstudio_lib/MainWindow.hpp
@@ -87,6 +87,8 @@ class MainWindow : public QMainWindow
 
   void enableComponentsMeasuresActions(bool enable);
 
+  bool geometryDiagnostics() const;
+
   QString lastPath() const;
 
   VerticalTabWidget* verticalTabWidget() {
@@ -181,6 +183,8 @@ class MainWindow : public QMainWindow
 
   void toggleVerboseOutput(bool verboseOutput);
 
+  void toggleGeometryDiagnostics(bool geometryDiagnostics);
+
   void promptAnalytics();
 
   void toggleAnalytics(bool allowAnalytics);
@@ -214,6 +218,8 @@ class MainWindow : public QMainWindow
   bool m_displayIP;
 
   bool m_verboseOutput = false;
+
+  bool m_geometryDiagnostics = false;
 
   QString m_currLang;
 

--- a/src/openstudio_lib/library/README.md
+++ b/src/openstudio_lib/library/README.md
@@ -9,5 +9,7 @@ Open the developer console (F12)
 Type this:
 
 ```
-runFromFile("./sample_data.json")
+runFromFile("./sample_data.json", true)
 ```
+
+The second parameter, the boolean, is whether you want to enable the Geometry Diagnostics UI or not

--- a/src/openstudio_lib/library/generate_sample_data.rb
+++ b/src/openstudio_lib/library/generate_sample_data.rb
@@ -2,7 +2,16 @@ require 'openstudio'
 
 m = OpenStudio::Model::exampleModel
 
+# Flip a wall
+wall = m.getSurfaces.select{|sf| sf.surfaceType.downcase.include?("wall") && sf.outsideBoundaryCondition.downcase == 'outdoors' }.first
+wall.setVertices(wall.vertices.reverse)
+
+# Delete a roof
+roof = m.getSurfaces.select{|sf| sf.surfaceType.downcase.include?("roof") }.first
+roof.remove
+
 ft = OpenStudio::Model::ThreeJSForwardTranslator.new
+ft.setIncludeGeometryDiagnostics(true)
 
 # Triangulate
 triangulate = true

--- a/src/openstudio_lib/library/geometry_preview.html
+++ b/src/openstudio_lib/library/geometry_preview.html
@@ -70,6 +70,7 @@
 
 // global variable, set in init
 var os_data;
+var includeGeometryDiagnostics;
 
 
 var renderer, scene, light, scene_objects, scene_edges, object_edges, coincident_objects, back_objects, dot_points;
@@ -431,10 +432,11 @@ function setCameraAngles(camera, controls, theta, phi, tweenTime) {
   });
 }
 
-function init(os_data_in) {
+function init(os_data_in, includeGeometryDiagnostics_in) {
 
   // set global variable
   os_data = os_data_in;
+  includeGeometryDiagnostics = includeGeometryDiagnostics_in;
 
   var css = document.head.appendChild(document.createElement('style'));
   css.innerHTML = 'body { font:600 12pt monospace; margin:0; overflow:hidden; }';
@@ -780,6 +782,10 @@ function onDocumentMouseClick(event) {
   }
 }
 
+function colorize_bool(b) {
+  return "<span style='color: " + (b ? 'green' : 'red') + ";'>" + b + '</span>'
+}
+
 function displaySelectedObjectDetails() {
 
   headsUp.style.left = 10 + 0.5 * window.innerWidth + mouse.x * 0.5 * window.innerWidth + 'px';
@@ -799,10 +805,12 @@ function displaySelectedObjectDetails() {
         if (inter.userData.spaceName){
           txt += 'Space Name: ' + inter.userData.spaceName;
         }
-        txt += 'Convex' + inter.userData.convex;
-        txt += 'CorrectlyOriented' + inter.userData.correctlyOriented;
-        txt += 'Space Convex: ' + inter.userData.spaceConvex;
-        txt += 'Space Enclosed: ' + inter.userData.spaceEnclosed;
+        if (includeGeometryDiagnostics) {
+          txt += '<br> Convex: ' + colorize_bool(inter.userData.convex);
+          txt += '<br> CorrectlyOriented: ' + colorize_bool(inter.userData.correctlyOriented);
+          txt += '<br> Space Convex: ' + colorize_bool(inter.userData.spaceConvex);
+          txt += '<br> Space Enclosed: ' + colorize_bool(inter.userData.spaceEnclosed);
+        }
         break;
       case "Normal":
         txt += 'Surface Type: ' + inter.userData.surfaceType + '<br>'
@@ -1115,17 +1123,19 @@ var update = function (value) {
       object.visible = adjacencyIssueIds.has(object.id);
     }
 
-    if (settings.showOnlyNonConvexSurfaces && object.userData.convex) {
-      object.visible = false;
-    }
-    if (settings.showOnlyNonConvexSpaces && object.userData.spaceConvex) {
-      object.visible = false;
-    }
-    if (settings.showOnlyNonEnclosedSpaces && object.userData.spaceEnclosed) {
-      object.visible = false;
-    }
-    if (settings.showOnlyIncorrectlyOrientedSurfaces && object.userData.correctlyOriented) {
-      object.visible = false;
+    if (includeGeometryDiagnostics) {
+      if (settings.showOnlyNonConvexSurfaces && object.userData.convex) {
+        object.visible = false;
+      }
+      if (settings.showOnlyNonConvexSpaces && object.userData.spaceConvex) {
+        object.visible = false;
+      }
+      if (settings.showOnlyNonEnclosedSpaces && object.userData.spaceEnclosed) {
+        object.visible = false;
+      }
+      if (settings.showOnlyIncorrectlyOrientedSurfaces && object.userData.correctlyOriented) {
+        object.visible = false;
+      }
     }
 
     if (settings.showStory !== 'All Stories' && settings.showStory !== object.userData.buildingStoryName) {
@@ -1453,34 +1463,36 @@ var initDatGui = function () {
     adjacencies.open();
   }
 
-  {
-    var surfaceLevelIssues =  diagnostics.addFolder('Surface Level Issues')
-    surfaceLevelIssues.add(settings, 'showOnlyNonConvexSurfaces').name('Non-Convex Surfaces Only').onChange(value => {
-        removeSelection();
-        setLocalStorage('showOnlyNonConvexSurfaces', value);
-        update(value);
-    });
-    surfaceLevelIssues.add(settings, 'showOnlyIncorrectlyOrientedSurfaces').name('Incorrectly Oriented Surfaces Only').onChange(value => {
-        removeSelection();
-        setLocalStorage('showOnlyIncorrectlyOrientedSurfaces', value);
-        update(value);
-    });
-    surfaceLevelIssues.open();
-  }
-  {
-    var spaceLevelIssues =  diagnostics.addFolder('Space Level Issues')
-    spaceLevelIssues.add(settings, 'showOnlyNonConvexSpaces').name('Non-Convex Spaces Only').onChange(value => {
-        removeSelection();
-        setLocalStorage('showOnlyNonConvexSpaces', value);
-        update(value);
-    });
+  if(includeGeometryDiagnostics) {
+    {
+      var surfaceLevelIssues =  diagnostics.addFolder('Surface Level Issues')
+      surfaceLevelIssues.add(settings, 'showOnlyNonConvexSurfaces').name('Non-Convex Surfaces Only').onChange(value => {
+          removeSelection();
+          setLocalStorage('showOnlyNonConvexSurfaces', value);
+          update(value);
+      });
+      surfaceLevelIssues.add(settings, 'showOnlyIncorrectlyOrientedSurfaces').name('Incorrectly Oriented Surfaces Only').onChange(value => {
+          removeSelection();
+          setLocalStorage('showOnlyIncorrectlyOrientedSurfaces', value);
+          update(value);
+      });
+      surfaceLevelIssues.open();
+    }
+    {
+      var spaceLevelIssues =  diagnostics.addFolder('Space Level Issues')
+      spaceLevelIssues.add(settings, 'showOnlyNonConvexSpaces').name('Non-Convex Spaces Only').onChange(value => {
+          removeSelection();
+          setLocalStorage('showOnlyNonConvexSpaces', value);
+          update(value);
+      });
 
-    spaceLevelIssues.add(settings, 'showOnlyNonEnclosedSpaces').name('Non-Enclosed Spaces Only').onChange(value => {
-        removeSelection();
-        setLocalStorage('showOnlyNonEnclosedSpaces', value);
-        update(value);
-    });
-    spaceLevelIssues.open();
+      spaceLevelIssues.add(settings, 'showOnlyNonEnclosedSpaces').name('Non-Enclosed Spaces Only').onChange(value => {
+          removeSelection();
+          setLocalStorage('showOnlyNonEnclosedSpaces', value);
+          update(value);
+      });
+      spaceLevelIssues.open();
+    }
   }
   diagnostics.open();
 
@@ -1519,8 +1531,8 @@ var initDatGui = function () {
  * runFromJSON: loads a ThreeJS JSON **string** representation file (passed from GeometryPreviewView typically)
  * @param  {string} data_json_str [the string representing the ThreeJS json data]
  */
-function runFromJSON(data_str) {
-  init(data_str);
+function runFromJSON(data_str, includeGeometryDiagnostics=false) {
+  init(data_str, includeGeometryDiagnostics);
   animate();
   initDatGui();
 }
@@ -1529,7 +1541,7 @@ function runFromJSON(data_str) {
  * runFromFile: loads a ThreeJS json representation file from disk and render it
  * @param  {string} data_json_file [the path to the json data, defaults to ./sample_data.json]
  */
-function runFromFile(data_json_file="./sample_data.json") {
+function runFromFile(data_json_file="./sample_data.json", includeGeometryDiagnostics=false) {
   // import data from './data.json' assert { type: 'JSON' };
   var depdata =  fetch(data_json_file).then((data) => {
       return data.json();
@@ -1538,7 +1550,7 @@ function runFromFile(data_json_file="./sample_data.json") {
   depdata.then(function(data) {
     console.log("loaded " + data_json_file + ": ");
     console.log(data);
-    init(data);
+    init(data, includeGeometryDiagnostics);
     animate();
     initDatGui();
   });

--- a/src/openstudio_lib/library/geometry_preview.html
+++ b/src/openstudio_lib/library/geometry_preview.html
@@ -136,8 +136,12 @@ var settings = {
   renderBy: 'Surface Type',
   showStory: 'All Stories',
   showAirLoop: 'All Loops',
-  findAdjacencyIssues: false,
-  findAdjacencyThreshold: 1,
+  findAdjacencyIssues: getBoolFromLocalStorage('findAdjacencyIssues', false),
+  findAdjacencyThreshold: getFloatFromLocalStorage('findAdjacencyThreshold', 1),
+  showOnlyNonConvexSurfaces: getBoolFromLocalStorage('showOnlyNonConvexSurfaces', false),
+  showOnlyNonConvexSpaces: getBoolFromLocalStorage('showOnlyNonConvexSpaces', false),
+  showOnlyNonEnclosedSpaces: getBoolFromLocalStorage('showOnlyNonEnclosedSpaces', false),
+  showOnlyIncorrectlyOrientedSurfaces: getBoolFromLocalStorage('showOnlyIncorrectlyOrientedSurfaces', false),
   searchType: getStringFromLocalStorage('searchType', 'Surfaces'),
   searchName: getStringFromLocalStorage('searchName', ''),
   showFloors: getBoolFromLocalStorage('showFloors', true),
@@ -795,6 +799,10 @@ function displaySelectedObjectDetails() {
         if (inter.userData.spaceName){
           txt += 'Space Name: ' + inter.userData.spaceName;
         }
+        txt += 'Convex' + inter.userData.convex;
+        txt += 'CorrectlyOriented' + inter.userData.correctlyOriented;
+        txt += 'Space Convex: ' + inter.userData.spaceConvex;
+        txt += 'Space Enclosed: ' + inter.userData.spaceEnclosed;
         break;
       case "Normal":
         txt += 'Surface Type: ' + inter.userData.surfaceType + '<br>'
@@ -1107,6 +1115,19 @@ var update = function (value) {
       object.visible = adjacencyIssueIds.has(object.id);
     }
 
+    if (settings.showOnlyNonConvexSurfaces && object.userData.convex) {
+      object.visible = false;
+    }
+    if (settings.showOnlyNonConvexSpaces && object.userData.spaceConvex) {
+      object.visible = false;
+    }
+    if (settings.showOnlyNonEnclosedSpaces && object.userData.spaceEnclosed) {
+      object.visible = false;
+    }
+    if (settings.showOnlyIncorrectlyOrientedSurfaces && object.userData.correctlyOriented) {
+      object.visible = false;
+    }
+
     if (settings.showStory !== 'All Stories' && settings.showStory !== object.userData.buildingStoryName) {
       object.visible = false;
     }
@@ -1412,22 +1433,56 @@ var initDatGui = function () {
   });
   f1.open();
 
-  var f2 = gui.addFolder('Potential Adjacency Issues');
-  f2.add(settings, 'findAdjacencyIssues').name('Enable').onChange(value => {
-      removeSelection();
-      setLocalStorage('findAdjacencyThreshold', value);
-      updateAdjacencyIssues();
-      update(value);
-  });
-  f2.add(settings, 'findAdjacencyThreshold', 0.1, 10, 0.5).name('Threshold').onFinishChange(function (value) {
-      if (settings.findAdjacencyIssues) {
-          removeSelection();
-          setLocalStorage('findAdjacencyThreshold', value);
-          updateAdjacencyIssues();
-          update(value);
-      }
-  });
-  f2.open();
+  var diagnostics = gui.addFolder("Diagnostic Tools")
+  {
+    var adjacencies = diagnostics.addFolder('Potential Adjacency Issues');
+    adjacencies.add(settings, 'findAdjacencyIssues').name('Enable').onChange(value => {
+        removeSelection();
+        setLocalStorage('findAdjacencyIssues', value);
+        updateAdjacencyIssues();
+        update(value);
+    });
+    adjacencies.add(settings, 'findAdjacencyThreshold', 0.1, 10, 0.5).name('Threshold').onFinishChange(function (value) {
+        if (settings.findAdjacencyIssues) {
+            removeSelection();
+            setLocalStorage('findAdjacencyThreshold', value);
+            updateAdjacencyIssues();
+            update(value);
+        }
+    });
+    adjacencies.open();
+  }
+
+  {
+    var surfaceLevelIssues =  diagnostics.addFolder('Surface Level Issues')
+    surfaceLevelIssues.add(settings, 'showOnlyNonConvexSurfaces').name('Non-Convex Surfaces Only').onChange(value => {
+        removeSelection();
+        setLocalStorage('showOnlyNonConvexSurfaces', value);
+        update(value);
+    });
+    surfaceLevelIssues.add(settings, 'showOnlyIncorrectlyOrientedSurfaces').name('Incorrectly Oriented Surfaces Only').onChange(value => {
+        removeSelection();
+        setLocalStorage('showOnlyIncorrectlyOrientedSurfaces', value);
+        update(value);
+    });
+    surfaceLevelIssues.open();
+  }
+  {
+    var spaceLevelIssues =  diagnostics.addFolder('Space Level Issues')
+    spaceLevelIssues.add(settings, 'showOnlyNonConvexSpaces').name('Non-Convex Spaces Only').onChange(value => {
+        removeSelection();
+        setLocalStorage('showOnlyNonConvexSpaces', value);
+        update(value);
+    });
+
+    spaceLevelIssues.add(settings, 'showOnlyNonEnclosedSpaces').name('Non-Enclosed Spaces Only').onChange(value => {
+        removeSelection();
+        setLocalStorage('showOnlyNonEnclosedSpaces', value);
+        update(value);
+    });
+    spaceLevelIssues.open();
+  }
+  diagnostics.open();
 
   var f3 = gui.addFolder('Camera');
   [

--- a/src/openstudio_lib/library/geometry_preview.html
+++ b/src/openstudio_lib/library/geometry_preview.html
@@ -1443,27 +1443,27 @@ var initDatGui = function () {
   });
   f1.open();
 
-  var diagnostics = gui.addFolder("Diagnostic Tools")
-  {
-    var adjacencies = diagnostics.addFolder('Potential Adjacency Issues');
-    adjacencies.add(settings, 'findAdjacencyIssues').name('Enable').onChange(value => {
-        removeSelection();
-        setLocalStorage('findAdjacencyIssues', value);
-        updateAdjacencyIssues();
-        update(value);
-    });
-    adjacencies.add(settings, 'findAdjacencyThreshold', 0.1, 10, 0.5).name('Threshold').onFinishChange(function (value) {
-        if (settings.findAdjacencyIssues) {
-            removeSelection();
-            setLocalStorage('findAdjacencyThreshold', value);
-            updateAdjacencyIssues();
-            update(value);
-        }
-    });
-    adjacencies.open();
-  }
-
   if(includeGeometryDiagnostics) {
+    var diagnostics = gui.addFolder("Diagnostic Tools")
+    {
+      var adjacencies = diagnostics.addFolder('Potential Adjacency Issues');
+      adjacencies.add(settings, 'findAdjacencyIssues').name('Enable').onChange(value => {
+          removeSelection();
+          setLocalStorage('findAdjacencyIssues', value);
+          updateAdjacencyIssues();
+          update(value);
+      });
+      adjacencies.add(settings, 'findAdjacencyThreshold', 0.1, 10, 0.5).name('Threshold').onFinishChange(function (value) {
+          if (settings.findAdjacencyIssues) {
+              removeSelection();
+              setLocalStorage('findAdjacencyThreshold', value);
+              updateAdjacencyIssues();
+              update(value);
+          }
+      });
+      adjacencies.open();
+    }
+
     {
       var surfaceLevelIssues =  diagnostics.addFolder('Surface Level Issues')
       surfaceLevelIssues.add(settings, 'showOnlyNonConvexSurfaces').name('Non-Convex Surfaces Only').onChange(value => {
@@ -1493,8 +1493,8 @@ var initDatGui = function () {
       });
       spaceLevelIssues.open();
     }
+    diagnostics.open();
   }
-  diagnostics.open();
 
   var f3 = gui.addFolder('Camera');
   [


### PR DESCRIPTION
* Supersedes #629 
* because it includes #628

----

## Opt-in feature to enable the geometry diagnostics from this PR:

* https://github.com/NREL/OpenStudio/pull/4843

![Convexity](https://github.com/openstudiocoalition/OpenStudioApplication/assets/5479063/601e32d7-a07c-48b5-8c6b-5e5c2e16f2e9)

# TODO:

* Having trouble tweaking the display of the dat GUI menu so that the labels won't be truncated as much.
    * The stylesheet is inlined in dat GUI. This can be seen here: https://github.com/openstudiocoalition/OpenStudioApplication/blob/6aee38e6f54b8b7a851ec5054f94c6b3aab71a47/src/openstudio_lib/library/js/dat.gui.0.7.9.js#L1673