### PR TITLE
Fix #638 - Make links clickable for measure descriptions

### DIFF
--- a/src/shared_gui_components/EditView.cpp
+++ b/src/shared_gui_components/EditView.cpp
@@ -179,6 +179,7 @@ DoubleInputView::DoubleInputView() : InputView() {
   setLayout(vLayout);
 
   nameLabel = new QLabel();
+  nameLabel->setOpenExternalLinks(true);
   nameLabel->setTextFormat(Qt::RichText);
   nameLabel->setWordWrap(true);
   vLayout->addWidget(nameLabel);
@@ -220,6 +221,7 @@ ChoiceInputView::ChoiceInputView() : InputView() {
   setLayout(vLayout);
 
   nameLabel = new QLabel();
+  nameLabel->setOpenExternalLinks(true);
   nameLabel->setWordWrap(true);
   vLayout->addWidget(nameLabel);
 
@@ -294,6 +296,7 @@ IntegerInputView::IntegerInputView() : InputView() {
   setLayout(vLayout);
 
   nameLabel = new QLabel();
+  nameLabel->setOpenExternalLinks(true);
   nameLabel->setWordWrap(true);
   vLayout->addWidget(nameLabel);
 
@@ -334,6 +337,7 @@ StringInputView::StringInputView() : InputView() {
   setLayout(vLayout);
 
   nameLabel = new QLabel();
+  nameLabel->setOpenExternalLinks(true);
   nameLabel->setWordWrap(true);
   vLayout->addWidget(nameLabel);
 
@@ -382,6 +386,7 @@ InputCheckBox::InputCheckBox() : QAbstractButton() {
   setLayout(mainHLayout);
 
   m_label = new QLabel();
+  m_label->setOpenExternalLinks(true);
   m_label->setWordWrap(true);
   mainHLayout->addWidget(m_label);
 


### PR DESCRIPTION
* Fix #638 
* Can't think of a side effect making this. We're not worried about phishing attempts