### PR TITLE
Bad workaround for #659

### DIFF
--- a/src/openstudio_lib/OSDocument.cpp
+++ b/src/openstudio_lib/OSDocument.cpp
@@ -126,6 +126,7 @@
 #include <QIcon>
 #include <QInputDialog>
 #include <QSettings>
+#include <QtGlobal>  // Workaround for #659
 
 #include <memory>
 
@@ -353,8 +354,11 @@ void OSDocument::setModel(const model::Model& model, bool modified, bool /*saveC
 }
 
 void OSDocument::weatherFileReset() {
+  // TODO: temporary workaround for #659
+#ifndef Q_OS_DARWIN
   QMessageBox::warning(mainWindow(), "Missing Weather File",
                        "Invalid weather file object, weather file object has been reset. Please choose another weather file.");
+#endif
 }
 
 void OSDocument::createTabButtons() {


### PR DESCRIPTION
Temporary workaround for #659 on mac. Just disabling the messagebox `Invalid weather file object, weather file object has been reset. Please choose another weather file`. Hopefully we find an actual fix, but in the meantime it's more important to be able to load a file than to see this warning messagebox.