### PR TITLE
Redo app build caching

### DIFF
--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -157,6 +157,8 @@ jobs:
           echo CONAN_USER_HOME=${{ github.workspace }}/conan-cache >> $GITHUB_ENV
           echo CONAN_USER_HOME_SHORT=${{ github.workspace }}/conan-cache/short >> $GITHUB_ENV
           echo CONAN_PROFILE_DEFAULT=${{ github.workspace }}/conan-cache/.conan/profiles/default >> $GITHUB_ENV
+          CCACHE_DIR=${{ github.workspace }}/.ccache
+          echo CCACHE_DIR=$CCACHE_DIR >> $GITHUB_ENV
         fi
 
         N=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
@@ -169,7 +171,7 @@ jobs:
           sudo apt install -y mesa-common-dev libglu1-mesa-dev patchelf ninja-build ccache libxkbcommon-x11-dev libgl1-mesa-dev chrpath
           gcc --version
 
-          ccache --set-config=cache_dir=${{ github.workspace }}/build/.ccache
+          ccache --set-config=cache_dir=$CCACHE_DIR
           ccache --set-config=max_size=500M
           ccache --set-config=compression=true
 
@@ -207,7 +209,7 @@ jobs:
             echo "Using brew to install ninja"
             brew install ninja md5sha1sum ccache
 
-            ccache --set-config=cache_dir=${{ github.workspace }}/build/.ccache
+            ccache --set-config=cache_dir=$CCACHE_DIR
             ccache --set-config=max_size=500M
             ccache --set-config=compression=true
             ccache --set-config=compiler_check=content # darwin only
@@ -293,14 +295,41 @@ jobs:
         ls $CONAN_USER_HOME/.conan/data
         ls $CONAN_USER_HOME/short || true
 
+    - name: Setup CCache
+      uses: actions/cache@v3
+      id: cacheccache
+      if: ${{ !matrix.SELF_HOSTED && runner.os != 'Windows' }}
+      with:
+        path: |
+          ${{ env.CCACHE_DIR}}
+        key: ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-cmakelists=${{ hashFiles('**/CMakeLists.txt') }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+        restore-keys: |
+          ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+
+    - name: Did restoring the CCache-cache work? Yes
+      # If the SDK wasn't found in the cache
+      if: steps.cacheccache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        ccache -s -vv
+
     # This includes the Qt install, the .ccache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
+    # TODO: problem is that caching is limited to 10 GB. The build folder takes 3-4 GB per runner, and we have 4 of them that try to cache
+    # Perhaps we should just cache the ccache. Anyways, for incremental builds triggered one after another, cache eviction hasn't happened yet and all of them do a cache hit
+    # Build times improvements
+    #  * Ubuntu: 41 min -> 10 min
+    #  * macos-13 (where conan binaries needed to be built): 1h15 ->  27min  (shaving 23 min due to conan cache only)
+    # Another thing is that if the cache is hit, then it's not saved in post build. Fine for the conan cache, but probably want an update for the build stuff
+    # Note that cache is immutable, so that'd mean uploading a NEW cache entry (so potentially 4GB again)
     - name: Cache entire build directory
       id: cachebuild
       if: ${{ !matrix.SELF_HOSTED }}
       uses: actions/cache@v3
       with:
-        path: build/
-        key: build-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-qt=${{ env.QT_VERSION }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT)}}-ck=${{ secrets.CACHE_KEY }}
+        path: |
+          build/Qt-install
+          build/OpenStudio-${{ env.OS_SDK_VERSION }}
+        key: minimal-build-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-qt=${{ env.QT_VERSION }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT)}}-ck=${{ secrets.CACHE_KEY }}
 
     - name: Did restoring the build-cache work? Yes
       # If it was found in the cache, list files, and Delete the packages already produced

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -405,6 +405,8 @@ jobs:
          ../
         ninja
         ninja package
+        # Delete conan build and source folders
+        conan remove "*" -s -b -f
 
     # Debug CPack:
     # "C:\Program Files\CMake\bin\cpack.exe" --debug --verbose --config CPackConfig.cmake
@@ -455,6 +457,8 @@ jobs:
         set -x
         ninja
         ninja package || ( echo "Package Step failed" && cpack --debug --verbose --config CPackConfig.cmake )
+        # Delete conan build and source folders
+        conan remove "*" -s -b -f
 
     - name: Test bed Sign inner portable executable files and exe package (Windows 2022)
       working-directory: ./build

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -57,8 +57,6 @@ jobs:
           COMPRESSED_PKG_PATH: _CPack_Packages/Linux/TGZ
           QT_OS_NAME: linux
           QT_ARCH: gcc_64
-          CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
-          CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
         - os: ubuntu-22.04
           SELF_HOSTED: false
           PLATFORM_NAME: Linux
@@ -72,8 +70,6 @@ jobs:
           COMPRESSED_PKG_PATH: _CPack_Packages/Linux/TGZ
           QT_OS_NAME: linux
           QT_ARCH: gcc_64
-          CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
-          CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
         - os: windows-2022
           SELF_HOSTED: false
           PLATFORM_NAME: Windows
@@ -87,8 +83,6 @@ jobs:
           COMPRESSED_PKG_PATH: _CPack_Packages/win64/ZIP
           QT_OS_NAME: windows
           QT_ARCH: win64_msvc2019_64
-          CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
-          CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
         - os: macos-13
           SELF_HOSTED: false
           PLATFORM_NAME: Darwin
@@ -104,8 +98,6 @@ jobs:
           SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
           QT_OS_NAME: mac
           QT_ARCH: clang_64
-          CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
-          CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
         - os: macos-arm64
           SELF_HOSTED: true
           PLATFORM_NAME: Darwin
@@ -154,8 +146,8 @@ jobs:
         echo CPACK_BINARY_TGZ=${{ matrix.CPACK_BINARY_TGZ }} >> $GITHUB_ENV
         echo BINARY_EXT=${{ matrix.BINARY_EXT }} >> $GITHUB_ENV
         if [ "${{ matrix.SELF_HOSTED }}" == "false" ]; then
-          echo CONAN_USER_HOME=${{ matrix.CONAN_USER_HOME }} >> $GITHUB_ENV
-          echo CONAN_USER_HOME_SHORT=${{ matrix.CONAN_USER_HOME_SHORT }} >> $GITHUB_ENV
+          echo CONAN_USER_HOME=${{ runner.workspace }}/conan-cache >> $GITHUB_ENV
+          echo CONAN_USER_HOME_SHORT=${{ runner.workspace }}/conan-cache/short >> $GITHUB_ENV
         fi
 
         N=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
@@ -247,7 +239,7 @@ jobs:
           conan profile update settings.compiler.libcxx=libstdc++11 default
         fi
         if [ "${{ matrix.SELF_HOSTED }}" == "false" ]; then
-          cat conan-cache/.conan/profiles/default
+          cat $CONAN_USER_HOME/.conan/profiles/default
         fi
 
     - name: Setup Conan Cache
@@ -265,9 +257,9 @@ jobs:
       working-directory: ${{ env.CONAN_USER_HOME }}
       shell: bash
       run: |
-        cat .conan/profiles/default
-        ls .conan/data
-        ls short || true
+        cat $CONAN_USER_HOME/.conan/profiles/default
+        ls $CONAN_USER_HOME/.conan/data
+        ls $CONAN_USER_HOME/short || true
 
     # This includes the Qt install, the .cache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
     - name: Cache entire build directory

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -29,6 +29,8 @@ env:
   CPACK_SOURCE_TZ: OFF
   CPACK_SOURCE_ZIP: OFF
   QT_VERSION: 6.6.1
+  CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
+  CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
   # CPACK_BINARY_DEB: OS-SPECIFIC
   # CPACK_BINARY_IFW: OS-SPECIFIC
 
@@ -115,7 +117,9 @@ jobs:
           QT_ARCH: arm_64
 
     steps:
+
     - uses: actions/checkout@v4
+
     - uses: actions/setup-python@v5
       if: ${{!matrix.SELF_HOSTED}}
       with:
@@ -126,127 +130,17 @@ jobs:
       with:
         ruby-version: 2.7
 
-    - name: Extract OSApp version from CMakeLists.txt
-      shell: python
+    - name: Extract OSApp and OS SDK versions from CMakeLists.txt
+      shell: bash
       run: |
-        import re
-        with open('CMakeLists.txt', 'r') as f:
-            content = f.read()
-        m = re.search('project\(OpenStudioApplication VERSION (\d+\.\d+\.\d+)\)', content)
-        version='X.Y.Z'
-        if m:
-            version = m.groups()[0]
-        with open('version.txt', 'w') as f:
-            f.write(version)
-
-    - name: Extract OS SDK version from FindOpenStudioSDK.cmake
-      shell: python
-      run: |
-        import re
-        import os
-        import urllib.parse as ul
-
-        with open('FindOpenStudioSDK.cmake', 'r') as f:
-            content = f.read()
-
-        no_comments_lines = []
-        for line in content.splitlines():
-            l = line.strip().split('#')[0]
-            if l:
-                no_comments_lines.append(l)
-        content = "\n".join(no_comments_lines)
-
-        m_major = re.search(r'set\(OPENSTUDIO_VERSION_MAJOR (\d+)\)', content)
-        m_minor = re.search(r'set\(OPENSTUDIO_VERSION_MINOR (\d+)\)', content)
-        m_patch = re.search(r'set\(OPENSTUDIO_VERSION_PATCH (\d+)\)', content)
-        m_sha = re.search(r'set\(OPENSTUDIO_VERSION_SHA "(.*?)"\)', content)
-
-        sdk_version = ''
-        if m_major:
-            OS_SDK_VERSION_MAJOR = m_major.groups()[0]
-            sdk_version += OS_SDK_VERSION_MAJOR
-            with open(os.environ['GITHUB_ENV'], 'a') as f:
-                f.write(f"\nOS_SDK_VERSION_MAJOR={OS_SDK_VERSION_MAJOR}")
-            print(f"\n{OS_SDK_VERSION_MAJOR=}")
-        else:
-            print("Unable to find OPENSTUDIO_VERSION_MAJOR")
-            sdk_version += 'X'
-
-        sdk_version += '.'
-        if m_minor:
-            OS_SDK_VERSION_MINOR = m_minor.groups()[0]
-            sdk_version += OS_SDK_VERSION_MINOR
-            with open(os.environ['GITHUB_ENV'], 'a') as f:
-                f.write(f"\nOS_SDK_VERSION_MINOR={OS_SDK_VERSION_MINOR}")
-            print(f"\n{OS_SDK_VERSION_MINOR=}")
-        else:
-            print("Unable to find OPENSTUDIO_VERSION_MINOR")
-            sdk_version += 'Y'
-
-        sdk_version += '.'
-        if m_patch:
-            OS_SDK_VERSION_PATCH = m_patch.groups()[0]
-            sdk_version += OS_SDK_VERSION_PATCH
-            with open(os.environ['GITHUB_ENV'], 'a') as f:
-                f.write(f"\nOS_SDK_VERSION_PATCH={OS_SDK_VERSION_PATCH}")
-            print(f"\n{OS_SDK_VERSION_PATCH=}")
-        else:
-            print("Unable to find OPENSTUDIO_VERSION_PATCH")
-            sdk_version += 'Z'
-
-        if m_sha:
-            OS_SDK_VERSION_SHA = m_sha.groups()[0]
-            # NOT ADDING IT to sdk_version
-            # sdk_version += OS_SDK_VERSION_SHA
-            with open(os.environ['GITHUB_ENV'], 'a') as f:
-                f.write(f"\nOS_SDK_VERSION_SHA={OS_SDK_VERSION_SHA}")
-            print(f"{OS_SDK_VERSION_SHA=}")
-        else:
-            print("Unable to find OPENSTUDIO_VERSION_SHA")
-
-        OS_SDK_VERSION = sdk_version
-        with open(os.environ['GITHUB_ENV'], 'a') as f:
-            f.write(f"\nOS_SDK_VERSION={OS_SDK_VERSION}")
-        print(f"{OS_SDK_VERSION=}")
-
-        with open('sdk_version.txt', 'a') as f:
-            f.write(sdk_version)
-
-        m_baselink = re.search(r'set\(OPENSTUDIO_BASELINK_RELEASE "(http.*?)"', content)
-        if m_baselink:
-            OS_SDK_BASELINK = m_baselink.groups()[0].replace('${OPENSTUDIO_VERSION}', sdk_version)
-            with open(os.environ['GITHUB_ENV'], 'a') as f:
-                f.write(f"\nOS_SDK_BASELINK={OS_SDK_BASELINK}")
-            print(f"Found baselink '{OS_SDK_BASELINK=}'")
-
-        else:
-            print("Unable to find OPENSTUDIO_BASELINK_RELEASE")
-            OS_SDK_BASELINK = f"https://github.com/NREL/OpenStudio/releases/download/v{sdk_version}{OS_SDK_VERSION_SHA.split('+')[0]}"
-            with open(os.environ['GITHUB_ENV'], 'a') as f:
-                f.write(f"\nOS_SDK_BASELINK={OS_SDK_BASELINK}")
-            print(f"Defaulted baselink '{OS_SDK_BASELINK=}'")
-
-        links = re.findall(r'"(https?:\/\/openstudio-ci-builds.*?)"', content)
-        links = [link.replace('${OPENSTUDIO_VERSION}', sdk_version) for link in links]
-        if len(links) > 0:
-            OS_SDK_ALTERNATE_LINK_1 = links[0]
-            with open(os.environ['GITHUB_ENV'], 'a') as f:
-                f.write(f"\nOS_SDK_ALTERNATE_LINK_1={OS_SDK_ALTERNATE_LINK_1}")
-            print(f"Alternate link '{OS_SDK_ALTERNATE_LINK_1=}'")
-
-        OS_SDK_INSTALLER_NAME = ul.quote_plus(f"OpenStudio-{sdk_version}{OS_SDK_VERSION_SHA}-Linux.deb")
-        with open(os.environ['GITHUB_ENV'], 'a') as f:
-            f.write(f"\nOS_SDK_INSTALLER_NAME={OS_SDK_INSTALLER_NAME}")
-        print(f"{OS_SDK_INSTALLER_NAME=}")
+        # This both prints the variables and adds them to GITHUB_ENV
+        python ci/parse_cmake_versions.py
 
     - name: Set OS-specific options and system dependencies (and QtIFW)
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
       run: |
-        OS_APP_VERSION=$(cat version.txt)
-        echo OS_APP_VERSION=$OS_APP_VERSION >> $GITHUB_ENV
-
         echo PLATFORM_NAME=${{ matrix.PLATFORM_NAME }} >> $GITHUB_ENV
         echo CPACK_BINARY_DEB=${{ matrix.CPACK_BINARY_DEB }} >> $GITHUB_ENV
         echo CPACK_BINARY_IFW=${{ matrix.CPACK_BINARY_IFW }} >> $GITHUB_ENV
@@ -262,11 +156,7 @@ jobs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           echo "Install needed system dependencies for OPENGL (due to Qt) for Linux"
           sudo apt update
-          sudo apt install -y mesa-common-dev libglu1-mesa-dev patchelf ninja-build libxkbcommon-x11-dev libgl1-mesa-dev chrpath
-
-          # Weirdly enough, ninja makes ubuntu unresponsive...
-          echo CMAKE_GENERATOR='Ninja' >> $GITHUB_ENV
-
+          sudo apt install -y mesa-common-dev libglu1-mesa-dev patchelf ninja-build ccache libxkbcommon-x11-dev libgl1-mesa-dev chrpath
           gcc --version
 
         elif [ "$RUNNER_OS" == "Windows" ]; then
@@ -291,21 +181,17 @@ jobs:
           # add folder containing vcvarsall.bat
           echo "$MSVC_DIR\VC\Auxiliary\Build" >> $GITHUB_PATH
         elif [ "$RUNNER_OS" == "macOS" ]; then
+          # The MACOSX_DEPLOYMENT_TARGET environment variable sets the default value for the CMAKE_OSX_DEPLOYMENT_TARGET variable.
           echo MACOSX_DEPLOYMENT_TARGET=${{ matrix.MACOSX_DEPLOYMENT_TARGET }} >> $GITHUB_ENV
           echo SDKROOT=${{ matrix.SDKROOT }} >> $GITHUB_ENV
           echo CMAKE_MACOSX_DEPLOYMENT_TARGET='-DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET' >> $GITHUB_ENV
-          # The MACOSX_DEPLOYMENT_TARGET environment variable sets the default value for the CMAKE_OSX_DEPLOYMENT_TARGET variable.
-          # echo CMAKE_MACOSX_DEPLOYMENT_TARGET='-DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET' >> $GITHUB_ENV
 
           if [ "${{matrix.SELF_HOSTED}}" = "true" ]; then
             echo "Using previously installed ninja and IFW"
             echo "/Users/irvinemac/Qt/Tools/QtInstallerFramework/4.3/bin/" >> $GITHUB_PATH
           else
             echo "Using brew to install ninja"
-            brew install ninja
-            echo CMAKE_GENERATOR='Ninja' >> $GITHUB_ENV
-
-            brew install md5sha1sum
+            brew install ninja md5sha1sum ccache
 
             # The openssl@3 package installed on CI adds these files to the pkgconfig directory
             # Remove them here so they aren't found instead of the version of OpenSSL built by Conan
@@ -335,122 +221,65 @@ jobs:
           fi;
         fi;
 
-        CONAN_INSTALL_MD5=$(md5sum ConanInstall.cmake | awk '{print $1}')
-        echo CONAN_INSTALL_MD5=$CONAN_INSTALL_MD5 >> $GITHUB_ENV
         cmake --version
 
+    - name: Install conan
+      shell: bash
+      run: |
+        python --version
+        pip install conan==1.59.0
+        conan --version
+        echo "Enabling conan revisions and setting parallel_download"
+        conan config set general.revisions_enabled=True
+        conan config set general.parallel_download=8
+        # We detect the profile and use that as one of the cache key parameters, so if GHA upgrades compilers it won't pick up old binaries
+        conan profile new --detect --force default
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          conan profile update settings.compiler.libcxx=libstdc++11 default
+        fi
+        cat ${{ env.CONAN_USER_HOME }}/.conan/profiles/default
+
+    - name: Setup Conan Cache
+      uses: actions/cache@v3
+      id: cacheconan
+      with:
+        path: |
+          ${{ env.CONAN_USER_HOME }}
+        key: ${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ hashFiles('./ConanInstall.txt') }}-${{ hashFiles('${{ env.CONAN_USER_HOME }}/.conan/profiles/default') }}-${{ secrets.CACHE_KEY }}
+
+    - name: Did restoring the conan-cache work? Yes
+      # If the SDK wasn't found in the cache
+      if: steps.cacheconan.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        cat ${{ env.CONAN_USER_HOME }}/.conan/profiles/default
+        ls ${{ env.CONAN_USER_HOME }}/.conan/data
+        ls ${{ env.CONAN_USER_HOME_SHORT }}
+
+    # This includes the Qt install, the .cache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
     - name: Cache entire build directory
       id: cachebuild
       if: ${{ !matrix.SELF_HOSTED }}
       uses: actions/cache@v3
       with:
         path: build/
-        key: ${{ matrix.os }}-${{ env.QT_VERSION }}-build-cache-v1-${{ secrets.CACHE_KEY }}
-
-    - name: Did restoring the build-cache work? No
-      # If the build cache wasn't found in the cache
-      if: steps.cachebuild.outputs.cache-hit != 'true'
-      run: |
-          echo "Build cache not found"
+        key: build-cache-${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ env.QT_VERSION }}-${{ hashFiles('${{ env.CONAN_USER_HOME }}/.conan/profiles/default') }}-${{ secrets.CACHE_KEY }}
 
     - name: Did restoring the build-cache work? Yes
       # If it was found in the cache, list files, and Delete the packages already produced
       if: steps.cachebuild.outputs.cache-hit == 'true'
       shell: bash
       run: |
-          ls build/ || true
-          cat build/CMakeCache.txt || true
-          /bin/rm build/OpenStudioApplication-*${{ env.PLATFORM_NAME }}* || true
-          ls build/ || true
-
-    - name: Cache OpenStudio tar.gz
-      id: cacheossdk
-      # To avoid downloading the SDK all the time, we try to cache it.
-      # The path matches both what FindOpenStudioSDK.cmake does and what the 'Download the OpenStudio installer' used to do
-      # If the build cache wasn't found in the cache (otherwise it will have the SDK subfolder already so this is pointless)"
-      if: ${{!matrix.SELF_HOSTED && steps.cachebuild.outputs.cache-hit != 'true'}}
-      uses: actions/cache@v3
-      with:
-        path: OpenStudio-${{ env.OS_SDK_VERSION }}
-        key: OpenStudio-SDK-${{ matrix.os }}-${{ env.OS_SDK_VERSION }}-${{ secrets.CACHE_KEY }}
-
-    - name: Did restoring the build-cache or OpenStudioSDK cache work? Yes
-      # If it wasn't found in the cache
-      if: ${{steps.cachebuild.outputs.cache-hit == 'true' || steps.cacheossdk.outputs.cache-hit == true}}
-      continue-on-error: true
-      run: |
-          ls build/ || true
-          ls build/OpenStudio-${{ env.OS_SDK_VERSION }} || true
-          ls build/Qt-install/ || true
-
-     # NOTE JM 2020-09-01: we're going to rely on FindOpenStudioSDK.cmake for now, but it's not impossible we'll need this in the future
-     # This step in conjuction with the step 'Create Build Environment and locate openstudio', and a small modification in 'Configure CMake' step
-     #
-#    - name: Download the OpenStudio installer
-#      # If the SDK wasn't found in the cache
-#      if: steps.cacheossdk.outputs.cache-hit != 'true'
-#      # Use a bash shell so we can use the same syntax for environment variable
-#      # access regardless of the host operating system
-#      # Note: wget not available on windows, even in bash, so use curl
-#      shell: bash
-#      run: |
-#        curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/NREL/OpenStudio/releases/tags/v$OS_SDK_VERSION > os_tag.json
-#        echo "PLATFORM_NAME=${{ env.PLATFORM_NAME }}"
-#        cat os_tag.json
-#        tar_gz_link=$(cat os_tag.json | jq -r '.assets | .[] | select(.name | contains("${{ env.PLATFORM_NAME }}")) | select(.name | contains("tar.gz")) | .browser_download_url')
-#        if [ -z "$tar_gz_link" ]; then
-#          echo "Could not locate the OpenStudio tar.gz for OS_SDK_VERSION=$OS_SDK_VERSION and PLATFORM_NAME=$PLATFORM_NAME"
-#          exit 1;
-#        fi;
-#        tar_gz_name=$(basename -- $tar_gz_link)
-#        tar_gz_name=$(python -c "import sys, urllib.parse as ul; print(ul.unquote_plus(\"$tar_gz_name\"))")
-#        echo "Downloading $tar_gz_link"
-#        echo "Normally, tar_gz_name=$tar_gz_name"
-#        curl -L --output "$tar_gz_name" "$tar_gz_link"
-#        ls
-#        ls -la $tar_gz_name
-#        echo "Extract this into the OpenStudio-$OS_SDK_VERSION directory, omitting the first directory level in the tar.gz"
-#        echo "This isn't working, so use cmake to tar, then rename"
-#        echo "tar xfz $tar_gz_name --strip-components 1 -C OpenStudio-$OS_SDK_VERSION"
-#        echo "cmake -E make_directory OpenStudio-$OS_SDK_VERSION"
-#        folder_name=${tar_gz_name%.tar.gz}
-#        echo "folder_name=$folder_name"
-#        cmake -E tar xfz "$tar_gz_name"
-#        cmake -E rename "$folder_name" "OpenStudio-$OS_SDK_VERSION"
-
-    - name: Install conan
-      run: |
-          python --version
-          pip install 'conan<2'
-          conan --version
-          echo "Enabling conan revisions and setting parallel_download"
-          conan config set general.revisions_enabled=True
-          conan config set general.parallel_download=8
-
-    # DLM: skip caching conan, causing too many problems
-    #- name: Cache conan cache?
-    #  # To avoid downloading the SDK all the time, we try to cache it
-    #  id: cacheconan
-    #  uses: actions/cache@v3
-    #  with:
-    #    path: |
-    #      ~/.conan
-    #    key: ${{ matrix.os }}-conan-cache-${{ env.CONAN_INSTALL_MD5 }}-${{ secrets.CACHE_KEY }}
-
-    - name: Did restoring the conan-cache work? No
-      # If the SDK wasn't found in the cache
-      #if: steps.cacheconan.outputs.cache-hit != 'true'
-      run: |
-          echo "Conan cache not found"
-          echo "Create the conan data directory"
-          conan user
-
-    #- name: Did restoring the conan-cache work? Yes
-    #  # If the SDK wasn't found in the cache
-    #  if: steps.cacheconan.outputs.cache-hit == 'true'
-    #  run: |
-    #      ls ~/.conan/
-    #      ls ~/.conan/data/
+        set -x
+        ls build/ || true
+        cat build/CMakeCache.txt || true
+        /bin/rm build/OpenStudioApplication-*${{ env.PLATFORM_NAME }}* || true
+        ls build/ || true
+        # Delete the archived OS SDK if not the expected version
+        if [ -d "build/OpenStudio-$OS_SDK_VERSION" ]; then
+          cd build/OpenStudio-$OS_SDK_VERSION
+          ls $OS_SDK_INSTALLER_NAME* || rm -Rf ./*
+        fi
 
     - name: Install Qt
       # Some projects don't allow in-source building, so create a separate build directory
@@ -469,7 +298,7 @@ jobs:
         else
           QT_INSTALL_DIR="$(pwd)/build/Qt-install/$QT_VERSION/${{ matrix.QT_ARCH }}"
         fi
-        rm -rf $QT_INSTALL_DIR
+
         if [ -d "$QT_INSTALL_DIR" ]; then
           echo "Qt $QT_VERSION already installed"
         else
@@ -514,28 +343,6 @@ jobs:
         #ls $QT_INSTALL_DIR/translations/qtwebengine_locales || true
         find $QT_INSTALL_DIR . -name "*.qm"
         find $QT_INSTALL_DIR . -name "*.pak"
-
-    #- name: Cache Qt dep cache?
-      ## To avoid downloading the Qt dependency all the time, we try to cache it
-      #id: cacheqt
-      #uses: actions/cache@v3
-      #with:
-        #path: build/qt_5_11_*.tar.gz
-        #key: ${{ matrix.os }}-qt-5-11-cache
-
-    #- name: Did restoring the qt cache work?
-      ## If the SDK wasn't found in the cache
-      #if: steps.cacheqt.outputs.cache-hit != 'true'
-      #run: |
-          #echo "qt tar.gz was not found"
-
-    #- name: Cache other dependencies
-      ## Should probably cache the CMake-downloaded Qt at least
-      #shell: bash
-      #run: |
-          #echo "Not implemented yet"
-          #echo "The more I think about it, the more I think we should cache the entire build/ directory to speed up builds"
-          #echo "We can use a manual counter in the key so we can effectively wipe the build directory when we want to"
 
     - name: Configure CMake & build (Windows)
       if: runner.os == 'Windows'
@@ -661,15 +468,14 @@ jobs:
       # build/_CPack_Packages/Linux/DEB/*.deb
       # build/_CPack_Packages/Darwin/IFW/*.dmg
       with:
-          name: OpenStudioApplication-${{ env.OS_APP_VERSION }}.${{ github.sha }}-${{ matrix.os }}.${{ env.BINARY_EXT }}
-          path: build/${{ matrix.BINARY_PKG_PATH }}/*.${{ env.BINARY_EXT }}
-          # path: build/_CPack_Packages/*/*/*.${{ env.BINARY_EXT }}
+        name: OpenStudioApplication-${{ env.OS_APP_VERSION }}.${{ github.sha }}-${{ matrix.os }}.${{ env.BINARY_EXT }}
+        path: build/${{ matrix.BINARY_PKG_PATH }}/*.${{ env.BINARY_EXT }}
 
     - name: Archive TGZ or ZIP artifacts
       uses: actions/upload-artifact@v4
       with:
-          name: OpenStudioApplication-${{ env.OS_APP_VERSION }}.${{ github.sha }}-${{ matrix.os }}.${{ env.COMPRESSED_EXT }}
-          path: build/${{ matrix.COMPRESSED_PKG_PATH }}/*.${{ env.COMPRESSED_EXT }}
+        name: OpenStudioApplication-${{ env.OS_APP_VERSION }}.${{ github.sha }}-${{ matrix.os }}.${{ env.COMPRESSED_EXT }}
+        path: build/${{ matrix.COMPRESSED_PKG_PATH }}/*.${{ env.COMPRESSED_EXT }}
 
     - name: Test
       working-directory: ./build
@@ -677,15 +483,15 @@ jobs:
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: |
-          Xvfb :99 &
-          export DISPLAY=:99
-          ctest -j -T test --output-on-failure --no-compress-output -C $BUILD_TYPE || true
+        Xvfb :99 &
+        export DISPLAY=:99
+        ctest -j -T test --output-on-failure --no-compress-output -C $BUILD_TYPE || true
 
     - name: Archive test results?
       uses: actions/upload-artifact@v4
       with:
-          name: OpenStudioApplication-${{ env.OS_APP_VERSION }}.${{ github.sha }}-${{ matrix.os }}-Test.xml
-          path: build/Testing/**/*.xml
+        name: OpenStudioApplication-${{ env.OS_APP_VERSION }}.${{ github.sha }}-${{ matrix.os }}-Test.xml
+        path: build/Testing/**/*.xml
 
     - name: Benchmark
       working-directory: ./build
@@ -700,31 +506,8 @@ jobs:
     - name: Archive benchmark results?
       uses: actions/upload-artifact@v4
       with:
-          name: OpenStudioApplication-${{ env.OS_APP_VERSION }}.${{ github.sha }}-${{ matrix.os }}-bench_results.csv
-          path: build/bench_results_*.csv
-
-    #- name: Create a release if triggered by a tag
-      #id: create_release_tag
-      #if: contains(github.ref, 'refs/tags')
-      #uses: actions/create-release@v1.1.1
-      #env:
-        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #with:
-        #tag_name: ${{ github.ref }}
-        #release_name: Release ${{ github.ref }}
-        #body: |
-          #Release Notes pending
-        #draft: false
-        #prerelease: true
-
-    #- name: Release Asset Glob
-      #if: contains(github.ref, 'refs/tags')
-      #uses: shogo82148/actions-upload-release-asset@v1
-      #env:
-        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #with:
-        #upload_url: ${{ steps.create_release_tag.outputs.upload_url }}
-        #asset_path: ./OpenStudioApplication-*
+        name: OpenStudioApplication-${{ env.OS_APP_VERSION }}.${{ github.sha }}-${{ matrix.os }}-bench_results.csv
+        path: build/bench_results_*.csv
 
     - name: Upload Binary installer to release
       if: contains(github.ref, 'refs/tags')

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -150,9 +150,9 @@ jobs:
         if [ "${{ matrix.SELF_HOSTED }}" == "true" ]; then
           echo CONAN_PROFILE_DEFAULT=$HOME/.conan/profiles/default >> $GITHUB_ENV
         else
-          echo CONAN_USER_HOME=${{ runner.workspace }}/conan-cache >> $GITHUB_ENV
-          echo CONAN_USER_HOME_SHORT=${{ runner.workspace }}/conan-cache/short >> $GITHUB_ENV
-          echo CONAN_PROFILE_DEFAULT=${{ runner.workspace }}/conan-cache/.conan/profiles/default >> $GITHUB_ENV
+          echo CONAN_USER_HOME=${{ github.workspace }}/conan-cache >> $GITHUB_ENV
+          echo CONAN_USER_HOME_SHORT=${{ github.workspace }}/conan-cache/short >> $GITHUB_ENV
+          echo CONAN_PROFILE_DEFAULT=${{ github.workspace }}/conan-cache/.conan/profiles/default >> $GITHUB_ENV
         fi
 
         N=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
@@ -257,6 +257,8 @@ jobs:
           echo hashFiles=${{ hashFiles(format('{0}/.conan/profiles/default', env.CONAN_USER_HOME)) }}
           echo $CONAN_PROFILE_DEFAULT
           echo hashFiles=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}
+          echo hashFiles_rel=${{ hashFiles('./conan-cache/.conan/profiles/default') }}
+          echo hashFiles_conanInstall=${{ hashFiles('./ConanInstall.cmake') }}
         fi
 
     - name: Setup Conan Cache

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -170,7 +170,7 @@ jobs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           echo "Install needed system dependencies for OPENGL (due to Qt) for Linux"
           sudo apt update -qq
-          sudo apt install -y mesa-common-dev libglu1-mesa-dev patchelf ninja-build ccache libxkbcommon-x11-dev libgl1-mesa-dev chrpath
+          sudo apt install -y mesa-common-dev libglu1-mesa-dev patchelf ninja-build ccache libxkbcommon-x11-dev libgl1-mesa-dev chrpath libxcb-cursor0
           gcc --version
 
           ccache --set-config=cache_dir=$CCACHE_DIR

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -237,7 +237,7 @@ jobs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           conan profile update settings.compiler.libcxx=libstdc++11 default
         fi
-        cat ${{ env.CONAN_USER_HOME }}/.conan/profiles/default
+        cat conan-cache/.conan/profiles/default
 
     - name: Setup Conan Cache
       uses: actions/cache@v3
@@ -245,16 +245,17 @@ jobs:
       with:
         path: |
           ${{ env.CONAN_USER_HOME }}
-        key: ${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ hashFiles('./ConanInstall.txt') }}-${{ hashFiles('${{ env.CONAN_USER_HOME }}/.conan/profiles/default') }}-${{ secrets.CACHE_KEY }}
+        key: ${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ hashFiles('./ConanInstall.cmake') }}-${{ hashFiles(format('{0}/.conan/profiles/default', env.CONAN_USER_HOME)) }}-${{ secrets.CACHE_KEY }}
 
     - name: Did restoring the conan-cache work? Yes
       # If the SDK wasn't found in the cache
       if: steps.cacheconan.outputs.cache-hit == 'true'
+      working-directory: ${{ env.CONAN_USER_HOME }}
       shell: bash
       run: |
-        cat ${{ env.CONAN_USER_HOME }}/.conan/profiles/default
-        ls ${{ env.CONAN_USER_HOME }}/.conan/data
-        ls ${{ env.CONAN_USER_HOME_SHORT }}
+        cat .conan/profiles/default
+        ls .conan/data
+        ls short || true
 
     # This includes the Qt install, the .cache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
     - name: Cache entire build directory
@@ -263,7 +264,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: build/
-        key: build-cache-${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ env.QT_VERSION }}-${{ hashFiles('${{ env.CONAN_USER_HOME }}/.conan/profiles/default') }}-${{ secrets.CACHE_KEY }}
+        key: build-cache-${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ env.QT_VERSION }}-${{ hashFiles(format('{0}/.conan/profiles/default', env.CONAN_USER_HOME)) }}-${{ secrets.CACHE_KEY }}
 
     - name: Did restoring the build-cache work? Yes
       # If it was found in the cache, list files, and Delete the packages already produced

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -153,6 +153,8 @@ jobs:
           echo CONAN_USER_HOME="${{ github.workspace }}\conan-cache" >> $GITHUB_ENV
           echo CONAN_USER_HOME_SHORT="${{ github.workspace }}\conan-cache\short" >> $GITHUB_ENV
           echo CONAN_PROFILE_DEFAULT="${{ github.workspace }}\conan-cache\.conan\profiles\default" >> $GITHUB_ENV
+          CCACHE_DIR="${{ github.workspace }}\.ccache"
+          echo CCACHE_DIR=$CCACHE_DIR >> $GITHUB_ENV
         else
           echo CONAN_USER_HOME=${{ github.workspace }}/conan-cache >> $GITHUB_ENV
           echo CONAN_USER_HOME_SHORT=${{ github.workspace }}/conan-cache/short >> $GITHUB_ENV
@@ -187,8 +189,12 @@ jobs:
           # using ccache fails to build .rc files on Windows
           # ccache is installed under chocolatey but `choco uninstall ccache` fails
           # setting CCACHE_DISABLE=1 did not work, just remove ccache
-          echo "Remove ccache if it exists"
-          rm -f "/c/ProgramData/Chocolatey/bin/ccache" || true
+          # echo "Remove ccache if it exists"
+          # rm -f "/c/ProgramData/Chocolatey/bin/ccache" || true
+          choco install ccache
+          ccache --set-config=cache_dir=$CCACHE_DIR
+          ccache --set-config=max_size=500M
+          ccache --set-config=compression=true
 
           # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
           MSVC_DIR=$(vswhere -products '*' -requires Microsoft.Component.MSBuild -property installationPath -latest)
@@ -244,6 +250,7 @@ jobs:
 
         cmake --version
         ccache --show-config || true
+        ccache --zero-stats || true
 
     - name: Install conan
       shell: bash
@@ -299,7 +306,7 @@ jobs:
     - name: Setup CCache
       uses: actions/cache@v3
       id: cacheccache
-      if: ${{ !matrix.SELF_HOSTED && runner.os != 'Windows' }}
+      if: ${{ !matrix.SELF_HOSTED }}
       with:
         path: |
           ${{ env.CCACHE_DIR}}
@@ -438,6 +445,7 @@ jobs:
         ninja package
         # Delete conan build and source folders
         conan remove "*" -s -b -f
+        ccache --show-stats -vv || ccache --show-stats || true
 
     # Debug CPack:
     # "C:\Program Files\CMake\bin\cpack.exe" --debug --verbose --config CPackConfig.cmake
@@ -490,6 +498,8 @@ jobs:
         ninja package || ( echo "Package Step failed" && cpack --debug --verbose --config CPackConfig.cmake )
         # Delete conan build and source folders
         conan remove "*" -s -b -f
+        # Show ccache stats
+        ccache --show-stats -vv || ccache --show-stats || true
 
     - name: Test bed Sign inner portable executable files and exe package (Windows 2022)
       working-directory: ./build

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -149,6 +149,10 @@ jobs:
         echo BINARY_EXT=${{ matrix.BINARY_EXT }} >> $GITHUB_ENV
         if [ "${{ matrix.SELF_HOSTED }}" == "true" ]; then
           echo CONAN_PROFILE_DEFAULT=$HOME/.conan/profiles/default >> $GITHUB_ENV
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+          echo CONAN_USER_HOME="${{ github.workspace }}\conan-cache" >> $GITHUB_ENV
+          echo CONAN_USER_HOME_SHORT="${{ github.workspace }}\conan-cache\short" >> $GITHUB_ENV
+          echo CONAN_PROFILE_DEFAULT="${{ github.workspace }}\conan-cache\.conan\profiles\default" >> $GITHUB_ENV
         else
           echo CONAN_USER_HOME=${{ github.workspace }}/conan-cache >> $GITHUB_ENV
           echo CONAN_USER_HOME_SHORT=${{ github.workspace }}/conan-cache/short >> $GITHUB_ENV

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -575,7 +575,7 @@ jobs:
       # NOTE: If you re-enable 'Download the OpenStudio installer' step, then pass `openstudio_DIR=$openstudio_DIR cmake [etc]`
       run: |
         set -x
-        cmake -DQT_INSTALL_DIR:PATH=$QT_INSTALL_DIR -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE \
+        cmake -G Ninja -DQT_INSTALL_DIR:PATH=$QT_INSTALL_DIR -DCMAKE_BUILD_TYPE:STRING=$BUILD_TYPE \
          -DBUILD_DOCUMENTATION:BOOL=$DBUILD_DOCUMENTATION -DBUILD_TESTING:BOOL=$BUILD_TESTING -DBUILD_BENCHMARK:BOOL=$BUILD_BENCHMARK \
          -DBUILD_PACKAGE:BOOL=$BUILD_PACKAGE -DCPACK_BINARY_DEB:BOOL=$CPACK_BINARY_DEB -DCPACK_BINARY_IFW:BOOL=$CPACK_BINARY_IFW \
          -DCPACK_BINARY_NSIS:BOOL=$CPACK_BINARY_NSIS -DCPACK_BINARY_RPM:BOOL=$CPACK_BINARY_RPM -DCPACK_BINARY_STGZ:BOOL=$CPACK_BINARY_STGZ \
@@ -609,8 +609,8 @@ jobs:
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: |
         set -x
-        echo "Building with $N threads"
-        cmake --build . --target package -j $N --config $BUILD_TYPE
+        ninja
+        ninja package || ( echo "Package Step failed" && cpack --debug --verbose --config CPackConfig.cmake )
 
     - name: Test bed Sign inner portable executable files and exe package (Windows 2022)
       working-directory: ./build

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -169,6 +169,10 @@ jobs:
           sudo apt install -y mesa-common-dev libglu1-mesa-dev patchelf ninja-build ccache libxkbcommon-x11-dev libgl1-mesa-dev chrpath
           gcc --version
 
+          ccache --set-config=cache_dir=${{ github.workspace }}/build/.ccache
+          ccache --set-config=max_size=500M
+          ccache --set-config=compression=true
+
         elif [ "$RUNNER_OS" == "Windows" ]; then
           curl -L -O https://download.qt.io/official_releases/qt-installer-framework/4.6.1/QtInstallerFramework-windows-x64-4.6.1.exe
           ./QtInstallerFramework-windows-x64-4.6.1.exe --verbose --script ./ci/install_script_qtifw.qs
@@ -203,6 +207,11 @@ jobs:
             echo "Using brew to install ninja"
             brew install ninja md5sha1sum ccache
 
+            ccache --set-config=cache_dir=${{ github.workspace }}/build/.ccache
+            ccache --set-config=max_size=500M
+            ccache --set-config=compression=true
+            ccache --set-config=compiler_check=content # darwin only
+
             # The openssl@3 package installed on CI adds these files to the pkgconfig directory
             # Remove them here so they aren't found instead of the version of OpenSSL built by Conan
             rm /usr/local/lib/pkgconfig/libcrypto.pc
@@ -230,10 +239,6 @@ jobs:
             echo "~/Qt/QtIFW-4.6.1/bin/" >> $GITHUB_PATH
           fi;
         fi;
-
-        # TODO: configure ccache
-        # https://github.com/hendrikmuhs/ccache-action/blob/4cb35b2ff44ce57e1f5f5221e26bd8fefcfe41d0/src/restore.ts#L48
-        # ccache --set-config=cache_dir=${{ runner.workspace }}/.ccache
 
         cmake --version
 
@@ -286,7 +291,7 @@ jobs:
         ls $CONAN_USER_HOME/.conan/data
         ls $CONAN_USER_HOME/short || true
 
-    # This includes the Qt install, the .cache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
+    # This includes the Qt install, the .ccache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
     - name: Cache entire build directory
       id: cachebuild
       if: ${{ !matrix.SELF_HOSTED }}

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -248,6 +248,8 @@ jobs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           conan profile update settings.compiler.libcxx=libstdc++11 default
         fi
+        conan profile show default
+
         if [ "${{ matrix.SELF_HOSTED }}" == "false" ]; then
           echo "runner.workspace=${{ runner.workspace }}"
           echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
@@ -268,7 +270,7 @@ jobs:
       with:
         path: |
           ${{ env.CONAN_USER_HOME }}
-        key: ${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ hashFiles('./ConanInstall.cmake') }}-${{ hashFiles(format('{0}/.conan/profiles/default', env.CONAN_USER_HOME)) }}-${{ secrets.CACHE_KEY }}
+        key: conan-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conaninstall=${{ hashFiles('./ConanInstall.cmake') }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
 
     - name: Did restoring the conan-cache work? Yes
       # If the SDK wasn't found in the cache
@@ -287,7 +289,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: build/
-        key: build-cache-${{ matrix.os }}-${{ env.BUILD_TYPE }}-${{ env.QT_VERSION }}-${{ hashFiles(format('{0}/.conan/profiles/default', env.CONAN_USER_HOME)) }}-${{ secrets.CACHE_KEY }}
+        key: build-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-qt=${{ env.QT_VERSION }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT)}}-ck=${{ secrets.CACHE_KEY }}
 
     - name: Did restoring the build-cache work? Yes
       # If it was found in the cache, list files, and Delete the packages already produced

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -283,6 +283,7 @@ jobs:
         fi
 
     # Note: I'm picking up the ccache before I do the conan cache, otheriwe on windows when trying to hashFiles('**/CMakeLists.txt') it looks into the conan folder which fails
+    # To prevent problems, changing to multiple more specific glob patterns
     - name: Setup CCache
       uses: actions/cache@v3
       id: cacheccache
@@ -290,7 +291,7 @@ jobs:
       with:
         path: |
           ${{ env.CCACHE_DIR}}
-        key: ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}-cmakelists=${{ hashFiles('**/CMakeLists.txt') }}
+        key: ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}-cmakelists=${{ hashFiles('CMakeLists.txt', 'src/*/CMakeLists.txt', '*/CMakeLists.txt') }}
         restore-keys: |
           ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}-
 

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -139,15 +139,20 @@ jobs:
       # access regardless of the host operating system
       shell: bash
       run: |
+        set -x
+        pwd
         echo PLATFORM_NAME=${{ matrix.PLATFORM_NAME }} >> $GITHUB_ENV
         echo CPACK_BINARY_DEB=${{ matrix.CPACK_BINARY_DEB }} >> $GITHUB_ENV
         echo CPACK_BINARY_IFW=${{ matrix.CPACK_BINARY_IFW }} >> $GITHUB_ENV
         echo CPACK_BINARY_ZIP=${{ matrix.CPACK_BINARY_ZIP }} >> $GITHUB_ENV
         echo CPACK_BINARY_TGZ=${{ matrix.CPACK_BINARY_TGZ }} >> $GITHUB_ENV
         echo BINARY_EXT=${{ matrix.BINARY_EXT }} >> $GITHUB_ENV
-        if [ "${{ matrix.SELF_HOSTED }}" == "false" ]; then
+        if [ "${{ matrix.SELF_HOSTED }}" == "true" ]; then
+          echo CONAN_PROFILE_DEFAULT=$HOME/.conan/profiles/default >> $GITHUB_ENV
+        else
           echo CONAN_USER_HOME=${{ runner.workspace }}/conan-cache >> $GITHUB_ENV
           echo CONAN_USER_HOME_SHORT=${{ runner.workspace }}/conan-cache/short >> $GITHUB_ENV
+          echo CONAN_PROFILE_DEFAULT=${{ runner.workspace }}/conan-cache/.conan/profiles/default >> $GITHUB_ENV
         fi
 
         N=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
@@ -222,11 +227,16 @@ jobs:
           fi;
         fi;
 
+        # TODO: configure ccache
+        # https://github.com/hendrikmuhs/ccache-action/blob/4cb35b2ff44ce57e1f5f5221e26bd8fefcfe41d0/src/restore.ts#L48
+        # ccache --set-config=cache_dir=${{ runner.workspace }}/.ccache
+
         cmake --version
 
     - name: Install conan
       shell: bash
       run: |
+        set -x
         python --version
         pip install 'conan<2'
         conan --version
@@ -239,7 +249,14 @@ jobs:
           conan profile update settings.compiler.libcxx=libstdc++11 default
         fi
         if [ "${{ matrix.SELF_HOSTED }}" == "false" ]; then
-          cat $CONAN_USER_HOME/.conan/profiles/default
+          echo "runner.workspace=${{ runner.workspace }}"
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          echo "github.workspace=${{ github.workspace }}"
+          cat $CONAN_PROFILE_DEFAULT
+          echo format=${{ format('{0}/.conan/profiles/default', env.CONAN_USER_HOME) }}
+          echo hashFiles=${{ hashFiles(format('{0}/.conan/profiles/default', env.CONAN_USER_HOME)) }}
+          echo $CONAN_PROFILE_DEFAULT
+          echo hashFiles=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}
         fi
 
     - name: Setup Conan Cache

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -165,7 +165,7 @@ jobs:
 
         if [ "$RUNNER_OS" == "Linux" ]; then
           echo "Install needed system dependencies for OPENGL (due to Qt) for Linux"
-          sudo apt update
+          sudo apt update -qq
           sudo apt install -y mesa-common-dev libglu1-mesa-dev patchelf ninja-build ccache libxkbcommon-x11-dev libgl1-mesa-dev chrpath
           gcc --version
 
@@ -280,6 +280,8 @@ jobs:
         path: |
           ${{ env.CONAN_USER_HOME }}
         key: conan-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conaninstall=${{ hashFiles('./ConanInstall.cmake') }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+        restore-keys: |
+          conan-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
 
     - name: Did restoring the conan-cache work? Yes
       # If the SDK wasn't found in the cache

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -282,6 +282,26 @@ jobs:
           echo hashFiles_conanInstall=${{ hashFiles('./ConanInstall.cmake') }}
         fi
 
+    # Note: I'm picking up the ccache before I do the conan cache, otheriwe on windows when trying to hashFiles('**/CMakeLists.txt') it looks into the conan folder which fails
+    - name: Setup CCache
+      uses: actions/cache@v3
+      id: cacheccache
+      if: ${{ !matrix.SELF_HOSTED }}
+      with:
+        path: |
+          ${{ env.CCACHE_DIR}}
+        key: ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-cmakelists=${{ hashFiles('**/CMakeLists.txt') }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+        restore-keys: |
+          ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+
+    - name: Did restoring the CCache-cache work? Yes
+      # If the SDK wasn't found in the cache
+      if: steps.cacheccache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        ccache --show-stats -vv || ccache --show-stats
+        ccache --zero-stats
+
     - name: Setup Conan Cache
       uses: actions/cache@v3
       id: cacheconan
@@ -302,25 +322,6 @@ jobs:
         cat $CONAN_USER_HOME/.conan/profiles/default
         ls $CONAN_USER_HOME/.conan/data
         ls $CONAN_USER_HOME/short || true
-
-    - name: Setup CCache
-      uses: actions/cache@v3
-      id: cacheccache
-      if: ${{ !matrix.SELF_HOSTED }}
-      with:
-        path: |
-          ${{ env.CCACHE_DIR}}
-        key: ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-cmakelists=${{ hashFiles('**/CMakeLists.txt') }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
-        restore-keys: |
-          ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
-
-    - name: Did restoring the CCache-cache work? Yes
-      # If the SDK wasn't found in the cache
-      if: steps.cacheccache.outputs.cache-hit == 'true'
-      shell: bash
-      run: |
-        ccache --show-stats -vv || ccache --show-stats
-        ccache --zero-stats
 
     # This includes the Qt install, the .ccache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
     # TODO: problem is that caching is limited to 10 GB. The build folder takes 3-4 GB per runner, and we have 4 of them that try to cache

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -29,8 +29,6 @@ env:
   CPACK_SOURCE_TZ: OFF
   CPACK_SOURCE_ZIP: OFF
   QT_VERSION: 6.6.1
-  CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
-  CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
   # CPACK_BINARY_DEB: OS-SPECIFIC
   # CPACK_BINARY_IFW: OS-SPECIFIC
 
@@ -59,6 +57,8 @@ jobs:
           COMPRESSED_PKG_PATH: _CPack_Packages/Linux/TGZ
           QT_OS_NAME: linux
           QT_ARCH: gcc_64
+          CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
+          CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
         - os: ubuntu-22.04
           SELF_HOSTED: false
           PLATFORM_NAME: Linux
@@ -72,6 +72,8 @@ jobs:
           COMPRESSED_PKG_PATH: _CPack_Packages/Linux/TGZ
           QT_OS_NAME: linux
           QT_ARCH: gcc_64
+          CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
+          CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
         - os: windows-2022
           SELF_HOSTED: false
           PLATFORM_NAME: Windows
@@ -85,6 +87,8 @@ jobs:
           COMPRESSED_PKG_PATH: _CPack_Packages/win64/ZIP
           QT_OS_NAME: windows
           QT_ARCH: win64_msvc2019_64
+          CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
+          CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
         - os: macos-13
           SELF_HOSTED: false
           PLATFORM_NAME: Darwin
@@ -100,6 +104,8 @@ jobs:
           SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
           QT_OS_NAME: mac
           QT_ARCH: clang_64
+          CONAN_USER_HOME: "${{ github.workspace }}/conan-cache"
+          CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-cache/short"
         - os: macos-arm64
           SELF_HOSTED: true
           PLATFORM_NAME: Darwin
@@ -121,12 +127,12 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v5
-      if: ${{!matrix.SELF_HOSTED}}
+      if: ${{ !matrix.SELF_HOSTED }}
       with:
         python-version: '3.8.x'
 
     - uses: ruby/setup-ruby@v1
-      if: ${{!matrix.SELF_HOSTED}}
+      if: ${{ !matrix.SELF_HOSTED }}
       with:
         ruby-version: 2.7
 
@@ -147,7 +153,10 @@ jobs:
         echo CPACK_BINARY_ZIP=${{ matrix.CPACK_BINARY_ZIP }} >> $GITHUB_ENV
         echo CPACK_BINARY_TGZ=${{ matrix.CPACK_BINARY_TGZ }} >> $GITHUB_ENV
         echo BINARY_EXT=${{ matrix.BINARY_EXT }} >> $GITHUB_ENV
-        echo COMPRESSED_EXT=${{ matrix.COMPRESSED_EXT }} >> $GITHUB_ENV
+        if [ "${{ matrix.SELF_HOSTED }}" == "false" ]; then
+          echo CONAN_USER_HOME=${{ matrix.CONAN_USER_HOME }} >> $GITHUB_ENV
+          echo CONAN_USER_HOME_SHORT=${{ matrix.CONAN_USER_HOME_SHORT }} >> $GITHUB_ENV
+        fi
 
         N=$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
         echo "There are $N threads available"
@@ -186,7 +195,7 @@ jobs:
           echo SDKROOT=${{ matrix.SDKROOT }} >> $GITHUB_ENV
           echo CMAKE_MACOSX_DEPLOYMENT_TARGET='-DCMAKE_OSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET' >> $GITHUB_ENV
 
-          if [ "${{matrix.SELF_HOSTED}}" = "true" ]; then
+          if [ "${{ matrix.SELF_HOSTED }}" = "true" ]; then
             echo "Using previously installed ninja and IFW"
             echo "/Users/irvinemac/Qt/Tools/QtInstallerFramework/4.3/bin/" >> $GITHUB_PATH
           else
@@ -227,7 +236,7 @@ jobs:
       shell: bash
       run: |
         python --version
-        pip install conan==1.59.0
+        pip install 'conan<2'
         conan --version
         echo "Enabling conan revisions and setting parallel_download"
         conan config set general.revisions_enabled=True
@@ -237,11 +246,14 @@ jobs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           conan profile update settings.compiler.libcxx=libstdc++11 default
         fi
-        cat conan-cache/.conan/profiles/default
+        if [ "${{ matrix.SELF_HOSTED }}" == "false" ]; then
+          cat conan-cache/.conan/profiles/default
+        fi
 
     - name: Setup Conan Cache
       uses: actions/cache@v3
       id: cacheconan
+      if: ${{ !matrix.SELF_HOSTED }}
       with:
         path: |
           ${{ env.CONAN_USER_HOME }}
@@ -286,7 +298,7 @@ jobs:
       # Some projects don't allow in-source building, so create a separate build directory
       # We'll use this as our working directory for all subsequent commands
       shell: bash
-      if: ${{!matrix.SELF_HOSTED}}
+      if: ${{ !matrix.SELF_HOSTED }}
       run: |
         set -x
         cmake -E make_directory ./build
@@ -324,7 +336,7 @@ jobs:
 
     - name: Find Qt (Self-Hosted)
       shell: bash
-      if: ${{matrix.SELF_HOSTED}}
+      if: ${{ matrix.SELF_HOSTED }}
       run: |
         set -x
         cmake -E make_directory ./build

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -243,6 +243,7 @@ jobs:
         fi;
 
         cmake --version
+        ccache --show-config || true
 
     - name: Install conan
       shell: bash
@@ -311,7 +312,8 @@ jobs:
       if: steps.cacheccache.outputs.cache-hit == 'true'
       shell: bash
       run: |
-        ccache -s -vv
+        ccache --show-stats -vv || ccache --show-stats
+        ccache --zero-stats
 
     # This includes the Qt install, the .ccache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
     # TODO: problem is that caching is limited to 10 GB. The build folder takes 3-4 GB per runner, and we have 4 of them that try to cache

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -290,9 +290,9 @@ jobs:
       with:
         path: |
           ${{ env.CCACHE_DIR}}
-        key: ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-cmakelists=${{ hashFiles('**/CMakeLists.txt') }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+        key: ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}-cmakelists=${{ hashFiles('**/CMakeLists.txt') }}
         restore-keys: |
-          ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+          ccache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}-
 
     - name: Did restoring the CCache-cache work? Yes
       # If the SDK wasn't found in the cache
@@ -309,9 +309,9 @@ jobs:
       with:
         path: |
           ${{ env.CONAN_USER_HOME }}
-        key: conan-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conaninstall=${{ hashFiles('./ConanInstall.cmake') }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+        key: conan-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}-conaninstall=${{ hashFiles('./ConanInstall.cmake') }}
         restore-keys: |
-          conan-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}
+          conan-cache-${{ matrix.os }}-build=${{ env.BUILD_TYPE }}-conan-profile=${{ hashFiles(env.CONAN_PROFILE_DEFAULT) }}-ck=${{ secrets.CACHE_KEY }}-
 
     - name: Did restoring the conan-cache work? Yes
       # If the SDK wasn't found in the cache
@@ -323,14 +323,9 @@ jobs:
         ls $CONAN_USER_HOME/.conan/data
         ls $CONAN_USER_HOME/short || true
 
-    # This includes the Qt install, the .ccache (ccache) folder on Unix, the OpenStudio SDK tar.gz, and previous build artifacts
-    # TODO: problem is that caching is limited to 10 GB. The build folder takes 3-4 GB per runner, and we have 4 of them that try to cache
+    # This includes the Qt install,  the OpenStudio SDK tar.gz,
+    # TODO: problem is that caching the entire build dir is limited to 10 GB. The build folder takes 3-4 GB per runner, and we have 4 of them that try to cache
     # Perhaps we should just cache the ccache. Anyways, for incremental builds triggered one after another, cache eviction hasn't happened yet and all of them do a cache hit
-    # Build times improvements
-    #  * Ubuntu: 41 min -> 10 min
-    #  * macos-13 (where conan binaries needed to be built): 1h15 ->  27min  (shaving 23 min due to conan cache only)
-    # Another thing is that if the cache is hit, then it's not saved in post build. Fine for the conan cache, but probably want an update for the build stuff
-    # Note that cache is immutable, so that'd mean uploading a NEW cache entry (so potentially 4GB again)
     - name: Cache entire build directory
       id: cachebuild
       if: ${{ !matrix.SELF_HOSTED }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ developer/msvc/Visualizers/all_concat.natvis
 .clangd/
 cppcheck.txt*
 clang_format.patch
+conan-cache

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ developer/msvc/Visualizers/all_concat.natvis
 cppcheck.txt*
 clang_format.patch
 conan-cache
+.ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Use ccache is available, has to be before "project()"
-find_program(CCACHE_PROGRAM ccache)
+find_program(CCACHE_PROGRAM NAMES ccache sccache)
 if(CCACHE_PROGRAM)
-  # Support Unix Makefiles and Ninja
-  message(STATUS "Using CCACHE")
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+  # Support: Unix Makefiles and Ninja only
+  # RULE_LAUNCH_COMPILE is an internal variable and makes RC compilation fail on windows, hence why we use the C/CXX COMPILER_LAUNCHER instead
+  message(STATUS "${CCACHE_PROGRAM} found and enabled")
+  set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM} CACHE FILEPATH "CXX compiler cache used")
+  set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM} CACHE FILEPATH "C compiler cache used")
 endif()
 
 project(OpenStudioApplication VERSION 1.7.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,8 @@ endif()
 include(FindOpenStudioSDK.cmake)
 
 ###############################################################################
-
+#                                C O N A N                                    #
 ###############################################################################
-# Conan
 
 # Note JM 2019-04-24: Another option is to globally set "print_run_commands = True" in ~/.conan/conan.conf
 option(CONAN_PRINT_RUN_COMMANDS "Log every conan self.run command" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Do not enable compiler specific extensions, for eg on GCC use -std=c++1z (=c++17) and not -std=gnu++17
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Use ccache is available, has to be before "project()"
+# Use ccache if available, has to be before "project()"
 find_program(CCACHE_PROGRAM NAMES ccache sccache)
 if(CCACHE_PROGRAM)
   # Support: Unix Makefiles and Ninja only

--- a/ConanInstall.cmake
+++ b/ConanInstall.cmake
@@ -1,8 +1,6 @@
 # This file lists and installs the Conan packages needed
 
-# TODO: DO NOT DO `set(CONAN_OPTIONS "")` since some higher level stuff is added via OpenStudioApplication
-# CONAN_QT is added by OpenStudioApplication
-
+# NOTE: DO NOT DO `set(CONAN_OPTIONS "")` since some higher level stuff may be added via OpenStudioApplication (we were toying on adding CONAN_QT at some point)
 
 if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
 
@@ -35,7 +33,6 @@ if(NOT CONAN_OPENSTUDIO_ALREADY_RUN)
   conan_check(VERSION 1.53.0 REQUIRED)
 
   message(STATUS "openstudio: RUNNING CONAN")
-
 
   conan_add_remote(NAME nrel INDEX 0
     URL https://conan.openstudio.net/artifactory/api/conan/openstudio)

--- a/ci/parse_cmake_versions.py
+++ b/ci/parse_cmake_versions.py
@@ -1,0 +1,77 @@
+import os
+import re
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+def parse_os_app_version(cmakelists_path: Path):
+    content = cmakelists_path.read_text()
+    m = re.search("project\(OpenStudioApplication VERSION (\d+\.\d+\.\d+)\)", content)
+    version = "X.Y.Z"
+    if m:
+        version = m.groups()[0]
+        print(f"OS_APP_VERSION={version}")
+
+    if "GITHUB_ENV" not in os.environ:
+        return
+    with open(os.environ["GITHUB_ENV"], "a") as f:
+        f.write(f"\nOS_APP_VERSION={version}")
+
+
+def parse_os_sdk_version(find_sdk_path: Path):
+    with open(find_sdk_path, "r") as f:
+        content = f.read()
+
+    no_comments_lines = []
+    for line in content.splitlines():
+        stripped_line = line.strip().split("#")[0]
+        if stripped_line:
+            no_comments_lines.append(stripped_line)
+    content = "\n".join(no_comments_lines)
+
+    m_major = re.search(r"set\(OPENSTUDIO_VERSION_MAJOR (\d+)\)", content)
+    m_minor = re.search(r"set\(OPENSTUDIO_VERSION_MINOR (\d+)\)", content)
+    m_patch = re.search(r"set\(OPENSTUDIO_VERSION_PATCH (\d+)\)", content)
+    m_prerelease = re.search(r'set\(OPENSTUDIO_VERSION_PRERELEASE "(.*)"\)', content)
+    m_sha = re.search(r'set\(OPENSTUDIO_VERSION_SHA "(.*?)"\)', content)
+
+    assert m_major, "Unable to find OPENSTUDIO_VERSION_MAJOR"
+    assert m_minor, "Unable to find OPENSTUDIO_VERSION_MINOR"
+    assert m_patch, "Unable to find OPENSTUDIO_VERSION_PATCH"
+    assert m_prerelease, "Unable to find OPENSTUDIO_VERSION_PRERELEASE"
+    assert m_sha, "Unable to find OPENSTUDIO_VERSION_SHA"
+
+    OS_SDK_VERSION_MAJOR = m_major.groups()[0]
+    OS_SDK_VERSION_MINOR = m_minor.groups()[0]
+    OS_SDK_VERSION_PATCH = m_patch.groups()[0]
+    OS_SDK_VERSION_PRERELEASE = m_prerelease.groups()[0]
+    OS_SDK_VERSION_SHA = m_sha.groups()[0]
+
+    OS_SDK_VERSION = f"{OS_SDK_VERSION_MAJOR}.{OS_SDK_VERSION_MINOR}.{OS_SDK_VERSION_PATCH}"
+    OS_SDK_INSTALLER_NAME = f"OpenStudio-{OS_SDK_VERSION}{OS_SDK_VERSION_PRERELEASE}{OS_SDK_VERSION_SHA}"
+
+    print(f"{OS_SDK_VERSION_MAJOR=}")
+    print(f"{OS_SDK_VERSION_MINOR=}")
+    print(f"{OS_SDK_VERSION_PATCH=}")
+    print(f"{OS_SDK_VERSION_PRERELEASE=}")
+    print(f"{OS_SDK_VERSION_SHA=}")
+    print(f"{OS_SDK_VERSION=}")
+    print(f"{OS_SDK_INSTALLER_NAME=}")
+
+    if "GITHUB_ENV" not in os.environ:
+        return
+
+    with open(os.environ["GITHUB_ENV"], "a") as f:
+        f.write(f"\nOS_SDK_VERSION_MAJOR={OS_SDK_VERSION_MAJOR}")
+        f.write(f"\nOS_SDK_VERSION_MINOR={OS_SDK_VERSION_MINOR}")
+        f.write(f"\nOS_SDK_VERSION_PATCH={OS_SDK_VERSION_PATCH}")
+        f.write(f"\nOS_SDK_VERSION={OS_SDK_VERSION}")
+        f.write(f"\nOS_SDK_VERSION={OS_SDK_VERSION}")
+        f.write(f"\nOS_SDK_VERSION_SHA={OS_SDK_VERSION_SHA}")
+        f.write(f"\nOS_SDK_INSTALLER_NAME={OS_SDK_INSTALLER_NAME}")
+
+
+if __name__ == "__main__":
+    parse_os_app_version(cmakelists_path=ROOT_DIR / "CMakeLists.txt")
+    parse_os_sdk_version(find_sdk_path=ROOT_DIR / "FindOpenStudioSDK.cmake")


### PR DESCRIPTION
I noticed an issue with how we cached the entire build directory...
* In most cases it doesn’t speed up anything
* Github limits caching to 10GB. We have 4 runners that cache about 3 to 4 GB, so we constantly exceed it
* We often pick up an outdated OS SDK installer

I’ve done some semi “clever” caching strategies now:

* Cache the conan cache. The key for the cache is computed from the autodetected conan profile (so specific to an OS, architecture, compiler version) + the hash of the ConanInstall.cmake
* Cache the build/Qt-install dir + OS SDK installer (but trash it later if it's not the exact one). This is dependent on the runner.os and the QT version we use
* Enable CCACHE on all platforms. This is dependent on the hash of the conan profile
    * I have a few caveats here: if the cache is hit, then it's not saved in post build. Fine for the conan cache, but probably want an update for the build stuff? ideally the cache would be updated constantly... I might revisit this. Note that cache is immutable, so that'd mean uploading a NEW cache entry


Build times improvements on a rebuild when the source hasn't changed:

* Ubuntu: 41 min -> 10 min
* macos-13 (where conan binaries needed to be built): 1h15 ->  27min  (shaving 23 min due to conan cache only)
* Windows: 1h15 -> 20 min (the compile step takes a penalty on initial ccache building, approx 1h versus 53 min without)
  

before:

<img width="1330" alt="image" src="https://github.com/openstudiocoalition/OpenStudioApplication/assets/5479063/6a0714fd-4c86-4f8d-8f95-3195cdc9ed48">

after:

<img width="1344" alt="image" src="https://github.com/openstudiocoalition/OpenStudioApplication/assets/5479063/f00cca57-4273-4a19-abc2-7007d261137d">
