### PR TITLE
Add early failure for too old macOS, XCode or target macOS version

### DIFF
--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -94,7 +94,7 @@ jobs:
           COMPRESSED_EXT: tar.gz
           BINARY_PKG_PATH: _CPack_Packages/Darwin/IFW
           COMPRESSED_PKG_PATH: _CPack_Packages/Darwin/TGZ
-          MACOSX_DEPLOYMENT_TARGET: 10.15
+          MACOSX_DEPLOYMENT_TARGET: 11.0
           SDKROOT: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
           QT_OS_NAME: mac
           QT_ARCH: clang_64

--- a/.github/workflows/manual_cli_test.yml
+++ b/.github/workflows/manual_cli_test.yml
@@ -37,7 +37,7 @@ jobs:
           PLATFORM_NAME: Darwin
           BINARY_EXT: dmg
           COMPRESSED_EXT: tar.gz
-          MACOSX_DEPLOYMENT_TARGET: 10.15
+          MACOSX_DEPLOYMENT_TARGET: 11.0
         - os: macos-arm64
           SELF_HOSTED: true
           PLATFORM_NAME: Darwin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,21 @@ if(APPLE)
   # Looking at cmake source code OS_RELEASE is already set to the output of `sw_vers -productVersion` which is what we want
   cmake_host_system_information(RESULT OSX_VERSION QUERY OS_RELEASE)
   message("-- OS_RELEASE variable is set to: " ${OSX_VERSION})
+
+  if(DEFINED XCODE_VERSION)
+    if(XCODE_VERSION VERSION_LESS "13.0")
+      message(FATAL_ERROR "The minimum required version of XCode for compiling OpenStudio is 13, however XCODE_VERSION is set to " ${XCODE_VERSION} ". Please upgrade XCode and try again.")
+    endif()
+  # When using a generator other than XCode, ${XCODE_VERSION} is not set. Verify that we have at least the minimum macOS version required for XCode 13
+  elseif(OSX_VERSION VERSION_LESS "11.3")
+    message(FATAL_ERROR "The minimum required version of XCode for compiling OpenStudio is 13, which requires macOS 11.3 or greater, however macOS version is set to " ${OSX_VERSION} ". Please upgrade macOS and XCode and try again.")
+  endif()
+
   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+    if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS "11.0")
+      message(FATAL_ERROR "The minimum required target version for macOS is 11.0, however CMAKE_OSX_DEPLOYMENT_TARGET is set to ${CMAKE_OSX_DEPLOYMENT_TARGET}. Please set CMAKE_OSX_DEPLOYMENT_TARGET to 11.0 or greater and try again.")
+    endif()
+
     message("Using CMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
     set(OSX_VERSION "${CMAKE_OSX_DEPLOYMENT_TARGET}")
   endif()


### PR DESCRIPTION
Qt6 mandates to target [macOS 11.0 or greater, but also to have XCode 13 or greater to compile](https://doc.qt.io/qt-6/macos.html#supported-versions). See this explicit error from the `lrelease` utility using XCode 12 on macOS 10.15.7:

```
FAILED: translations/OpenStudioApp_de.qm /.../OpenStudioApplication/build/translations/OpenStudioApp_de.qm
cd /.../OpenStudioApplication/build/translations && /.../Qt/6.6.1/macos/bin/lrelease /.../OpenStudioApplication/translations/OpenStudioApp_de.ts -qm /...OpenStudioApplication/build/translations/OpenStudioApp_de.qm
Sorry, "lrelease" cannot be run on this version of macOS. Qt requires macOS 11.0.0 or later, you have macOS 10.15.7.
```

This PR adds early checks for these hard requirements.