### PR TITLE
Install openstudio to bin directory so it can be found relative to lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -749,10 +749,10 @@ install(DIRECTORY "${openstudio_ROOT_DIR}/Python" DESTINATION "." COMPONENT "Pyt
 # TODO: at 3.5.0, the lib/ directory on UNIX (only UNIX) contains the libopenstudiolib.so, but also the librubyengine.so, libpythonengine.so
 # install(DIRECTORY "${openstudio_ROOT_DIR}/lib" DESTINATION "." COMPONENT "OpenStudioApp" USE_SOURCE_PERMISSIONS)
 
-if(NOT APPLE)
-  # On Mac, in openstudio_app/CMakeLists.txt we've already copied the CLI to the OpenStudio.app/Contents/MacOS
-  install(IMPORTED_RUNTIME_ARTIFACTS openstudio::openstudio DESTINATION bin COMPONENT "CLI")
-endif()
+# On Mac, in openstudio_app/CMakeLists.txt we've already copied the CLI to the OpenStudio.app/Contents/MacOS
+# However, it is still needed in the bin directory so it can be found relative to the files in lib, this occurs
+# when a measure tries to use getOpenStudioCLI, see #695
+install(IMPORTED_RUNTIME_ARTIFACTS openstudio::openstudio DESTINATION bin COMPONENT "CLI")
 install(IMPORTED_RUNTIME_ARTIFACTS openstudio::openstudiolib DESTINATION ${LIB_DESTINATION_DIR} COMPONENT "CLI")
 install(IMPORTED_RUNTIME_ARTIFACTS openstudio::rubyengine DESTINATION ${LIB_DESTINATION_DIR} COMPONENT "CLI")
 install(IMPORTED_RUNTIME_ARTIFACTS openstudio::pythonengine DESTINATION ${LIB_DESTINATION_DIR} COMPONENT "CLI")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -749,10 +749,13 @@ install(DIRECTORY "${openstudio_ROOT_DIR}/Python" DESTINATION "." COMPONENT "Pyt
 # TODO: at 3.5.0, the lib/ directory on UNIX (only UNIX) contains the libopenstudiolib.so, but also the librubyengine.so, libpythonengine.so
 # install(DIRECTORY "${openstudio_ROOT_DIR}/lib" DESTINATION "." COMPONENT "OpenStudioApp" USE_SOURCE_PERMISSIONS)
 
-# On Mac, in openstudio_app/CMakeLists.txt we've already copied the CLI to the OpenStudio.app/Contents/MacOS
-# However, it is still needed in the bin directory so it can be found relative to the files in lib, this occurs
-# when a measure tries to use getOpenStudioCLI, see #695
-install(IMPORTED_RUNTIME_ARTIFACTS openstudio::openstudio DESTINATION bin COMPONENT "CLI")
+if(NOT APPLE)
+  # On Mac, we want to have openstudio CLI next to the OpenStudioApp in ./OpenStudio.app/Contents/MacOS
+  # But we still need it in the ./bin directory so it can be found relative to the files in ./lib, this occurs when a measure tries to use getOpenStudioCLI, see #695
+  # In openstudio_app/CMakeLists.txt we've already copied the CLI to the OpenStudio.app/Contents/MacOS, and we install a symlink to ./bin as well
+  # TODO: the link order is the reverse of the lib ones (where we create a symlink **in the bundle** that points to the ./lib contents)
+  install(IMPORTED_RUNTIME_ARTIFACTS openstudio::openstudio DESTINATION bin COMPONENT "CLI")
+endif()
 install(IMPORTED_RUNTIME_ARTIFACTS openstudio::openstudiolib DESTINATION ${LIB_DESTINATION_DIR} COMPONENT "CLI")
 install(IMPORTED_RUNTIME_ARTIFACTS openstudio::rubyengine DESTINATION ${LIB_DESTINATION_DIR} COMPONENT "CLI")
 install(IMPORTED_RUNTIME_ARTIFACTS openstudio::pythonengine DESTINATION ${LIB_DESTINATION_DIR} COMPONENT "CLI")

--- a/src/openstudio_app/CMakeLists.txt
+++ b/src/openstudio_app/CMakeLists.txt
@@ -459,6 +459,7 @@ if( APPLE )
           "../../../lib/$<TARGET_FILE_NAME:openstudio::openstudiolib>"
           "${CMAKE_INSTALL_PREFIX}/OpenStudioApp.app/Contents/Frameworks/$<TARGET_FILE_NAME:openstudio::openstudiolib>"
 
+        COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_INSTALL_PREFIX}/bin"
         COMMAND "${CMAKE_COMMAND}" -E create_symlink
           "../OpenStudioApp.app/Contents/MacOS/$<TARGET_FILE_NAME:openstudio::openstudio>"
           "${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:openstudio::openstudio>"

--- a/src/openstudio_app/CMakeLists.txt
+++ b/src/openstudio_app/CMakeLists.txt
@@ -459,6 +459,10 @@ if( APPLE )
           "../../../lib/$<TARGET_FILE_NAME:openstudio::openstudiolib>"
           "${CMAKE_INSTALL_PREFIX}/OpenStudioApp.app/Contents/Frameworks/$<TARGET_FILE_NAME:openstudio::openstudiolib>"
 
+        COMMAND "${CMAKE_COMMAND}" -E create_symlink
+          "../OpenStudioApp.app/Contents/MacOS/$<TARGET_FILE_NAME:openstudio::openstudio>"
+          "${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:openstudio::openstudio>"
+
         COMMAND_ECHO STDOUT
         COMMAND_ERROR_IS_FATAL ANY
       )


### PR DESCRIPTION
Install openstudio to bin directory so it can be found relative to lib, fixes #695

Basically, the openstudio CLI loads the libs from the lib folder, then getOpenStudioCLI looks for the CLI based on the libs paths.