### PR TITLE
Correctly remove old measures when downloading new ones

### DIFF
--- a/src/openstudio_lib/OSDocument.cpp
+++ b/src/openstudio_lib/OSDocument.cpp
@@ -1420,6 +1420,11 @@ size_t OSDocument::removeOutdatedLocalComponents(const std::string& uid, const s
   // }
   // return result;
 
+  auto components = getLocalComponents();
+  if (components.empty()) {
+    return {};
+  }
+
   // Not empty, we do have a localbcl
   components.erase(std::remove_if(components.begin(), components.end(),
                                   [&uid, &currentVersionId](const auto& component) {
@@ -1434,6 +1439,17 @@ size_t OSDocument::removeOutdatedLocalComponents(const std::string& uid, const s
 
 size_t OSDocument::removeOutdatedLocalMeasures(const std::string& uid, const std::string& currentVersionId) const {
   // TODO: when https://github.com/NREL/OpenStudio/pull/5129 is merged, we can just call it
+  // size_t result = 0;
+  // if (m_haveLocalBCL) {
+  //   try {
+  //     result = LocalBCL::instance().removeOutdatedLocalMeasures(uid, currentVersionId);
+  //   } catch (const std::exception& e) {
+  //     LOG(Error, "Cannot access local BCL: " << e.what());
+  //     m_haveLocalBCL = false;
+  //   }
+  // }
+  // return result;
+
   auto measures = getLocalMeasures();
   if (measures.empty()) {
     return {};

--- a/src/openstudio_lib/OSDocument.cpp
+++ b/src/openstudio_lib/OSDocument.cpp
@@ -1380,6 +1380,25 @@ boost::optional<BCLComponent> OSDocument::getLocalComponent(const std::string& u
   return result;
 }
 
+size_t OSDocument::removeOutdatedLocalComponents(const std::string& uid, const std::string& currentVersionId) {
+  size_t result = 0;
+  if (m_haveLocalBCL) {
+    try {
+      for (auto& oldComponent : LocalBCL::instance().components()) {
+        if ((oldComponent.uid() == uid) && (oldComponent.versionId() != currentVersionId)) {
+          if (LocalBCL::instance().removeComponent(oldComponent)) {
+            ++result;
+          }
+        }
+      }
+    } catch (const std::exception& e) {
+      LOG(Error, "Cannot access local BCL: " << e.what());
+      m_haveLocalBCL = false;
+    }
+  }
+  return result;
+}
+
 boost::optional<BCLMeasure> OSDocument::getLocalMeasure(const std::string& uid) const {
   boost::optional<BCLMeasure> result;
   if (m_haveLocalBCL) {
@@ -1406,11 +1425,17 @@ boost::optional<BCLMeasure> OSDocument::getLocalMeasure(const std::string& uid, 
   return result;
 }
 
-std::vector<BCLComponent> OSDocument::getLocalComponents() const {
-  std::vector<BCLComponent> result;
+size_t OSDocument::removeOutdatedLocalMeasures(const std::string& uid, const std::string& currentVersionId) {
+  size_t result = 0;
   if (m_haveLocalBCL) {
     try {
-      result = LocalBCL::instance().components();
+      for (auto& oldMeasure : LocalBCL::instance().measures()) {
+        if ((oldMeasure.uid() == uid) && (oldMeasure.versionId() != currentVersionId)) {
+          if (LocalBCL::instance().removeMeasure(oldMeasure)) {
+            ++result;
+          }
+        }
+      }
     } catch (const std::exception& e) {
       LOG(Error, "Cannot access local BCL: " << e.what());
       m_haveLocalBCL = false;

--- a/src/openstudio_lib/OSDocument.cpp
+++ b/src/openstudio_lib/OSDocument.cpp
@@ -1406,6 +1406,19 @@ boost::optional<BCLMeasure> OSDocument::getLocalMeasure(const std::string& uid, 
   return result;
 }
 
+std::vector<BCLComponent> OSDocument::getLocalComponents() const {
+  std::vector<BCLComponent> result;
+  if (m_haveLocalBCL) {
+    try {
+      result = LocalBCL::instance().components();
+    } catch (const std::exception& e) {
+      LOG(Error, "Cannot access local BCL: " << e.what());
+      m_haveLocalBCL = false;
+    }
+  }
+  return result;
+}
+
 std::vector<BCLMeasure> OSDocument::getLocalMeasures() const {
   std::vector<BCLMeasure> result;
   if (m_haveLocalBCL) {

--- a/src/openstudio_lib/OSDocument.hpp
+++ b/src/openstudio_lib/OSDocument.hpp
@@ -130,6 +130,7 @@ class OPENSTUDIO_API OSDocument : public OSQObjectController
   boost::optional<BCLMeasure> getLocalMeasure(const std::string& uid) const;
   boost::optional<BCLMeasure> getLocalMeasure(const std::string& uid, const std::string& versionId) const;
 
+  std::vector<BCLComponent> getLocalComponents() const;
   std::vector<BCLMeasure> getLocalMeasures() const;
 
   std::vector<BCLComponent> componentAttributeSearch(const std::vector<std::pair<std::string, std::string>>& pairs) const;

--- a/src/openstudio_lib/OSDocument.hpp
+++ b/src/openstudio_lib/OSDocument.hpp
@@ -126,11 +126,11 @@ class OPENSTUDIO_API OSDocument : public OSQObjectController
 
   boost::optional<BCLComponent> getLocalComponent(const std::string& uid) const;
   boost::optional<BCLComponent> getLocalComponent(const std::string& uid, const std::string& versionId) const;
+  size_t removeOutdatedLocalComponents(const std::string& uid, const std::string& currentVersionId);
 
   boost::optional<BCLMeasure> getLocalMeasure(const std::string& uid) const;
   boost::optional<BCLMeasure> getLocalMeasure(const std::string& uid, const std::string& versionId) const;
-
-  std::vector<BCLComponent> getLocalComponents() const;
+  size_t removeOutdatedLocalMeasures(const std::string& uid, const std::string& currentVersionId);
   std::vector<BCLMeasure> getLocalMeasures() const;
 
   std::vector<BCLComponent> componentAttributeSearch(const std::vector<std::pair<std::string, std::string>>& pairs) const;

--- a/src/openstudio_lib/openstudio.qrc
+++ b/src/openstudio_lib/openstudio.qrc
@@ -1173,6 +1173,8 @@
     <file alias="images/checked_checkbox_green@2x.png">../shared_gui_components/images/checked_checkbox_green@2x.png</file>
     <file alias="images/checked_checkbox_locked.png">../shared_gui_components/images/checked_checkbox_locked.png</file>
     <file alias="images/checked_checkbox_locked@2x.png">../shared_gui_components/images/checked_checkbox_locked@2x.png</file>
+    <file alias="images/checked_checkbox_update_available.png">../shared_gui_components/images/checked_checkbox_update_available.png</file>
+    <file alias="images/checked_checkbox_update_available@2x.png">../shared_gui_components/images/checked_checkbox_update_available@2x.png</file>
     <file alias="images/delete_softer.png">../shared_gui_components/images/delete_softer.png</file>
     <file alias="images/delete_softer@2x.png">../shared_gui_components/images/delete_softer@2x.png</file>
     <file alias="images/delete_softer_over.png">../shared_gui_components/images/delete_softer_over.png</file>
@@ -1231,6 +1233,10 @@
     <file alias="images/openstudio_measure_icon_Ruby@2x.png">../shared_gui_components/images/openstudio_measure_icon_Ruby@2x.png</file>
     <file alias="images/partially_checked_checkbox.png">../shared_gui_components/images/partially_checked_checkbox.png</file>
     <file alias="images/partially_checked_checkbox@2x.png">../shared_gui_components/images/partially_checked_checkbox@2x.png</file>
+    <file alias="images/partially_checked_checkbox_locked.png">../shared_gui_components/images/partially_checked_checkbox_locked.png</file>
+    <file alias="images/partially_checked_checkbox_locked@2x.png">../shared_gui_components/images/partially_checked_checkbox_locked@2x.png</file>
+    <file alias="images/partially_checked_checkbox_update_available.png">../shared_gui_components/images/partially_checked_checkbox_update_available.png</file>
+    <file alias="images/partially_checked_checkbox_update_available@2x.png">../shared_gui_components/images/partially_checked_checkbox_update_available@2x.png</file>
     <file alias="images/pause_over.png">../shared_gui_components/images/pause_over.png</file>
     <file alias="images/pause_over@2x.png">../shared_gui_components/images/pause_over@2x.png</file>
     <file alias="images/pause_press.png">../shared_gui_components/images/pause_press.png</file>
@@ -1281,6 +1287,8 @@
     <file alias="images/unchecked_checkbox_green@2x.png">../shared_gui_components/images/unchecked_checkbox_green@2x.png</file>
     <file alias="images/unchecked_checkbox_locked.png">../shared_gui_components/images/unchecked_checkbox_locked.png</file>
     <file alias="images/unchecked_checkbox_locked@2x.png">../shared_gui_components/images/unchecked_checkbox_locked@2x.png</file>
+    <file alias="images/unchecked_checkbox_update_available.png">../shared_gui_components/images/unchecked_checkbox_update_available.png</file>
+    <file alias="images/unchecked_checkbox_update_available@2x.png">../shared_gui_components/images/unchecked_checkbox_update_available@2x.png</file>
     <file alias="images/check_for_updates.png">../shared_gui_components/images/check_for_updates.png</file>
     <file alias="images/check_for_updates@2x.png">../shared_gui_components/images/check_for_updates@2x.png</file>
 

--- a/src/shared_gui_components/BuildingComponentDialogCentralWidget.cpp
+++ b/src/shared_gui_components/BuildingComponentDialogCentralWidget.cpp
@@ -287,10 +287,12 @@ void BuildingComponentDialogCentralWidget::comboBoxIndexChanged(const QString& t
 void BuildingComponentDialogCentralWidget::componentDownloadComplete(const std::string& uid, const boost::optional<BCLComponent>& component) {
   if (component) {
     // good
-    // remove old component
-    boost::optional<BCLComponent> oldComponent = OSAppBase::instance()->currentDocument()->getLocalComponent(component->uid());
-    if (oldComponent && oldComponent->versionId() != component->versionId()) {
-      LocalBCL::instance().removeComponent(*oldComponent);
+
+    // remove old components
+    for (auto& oldComponent : OSAppBase::instance()->currentDocument()->getLocalComponents()) {
+      if ((oldComponent.uid() == component->uid()) && (oldComponent.versionId() != component->versionId())) {
+        LocalBCL::instance().removeComponent(oldComponent);
+      }
     }
   } else {
     // error downloading component
@@ -306,11 +308,13 @@ void BuildingComponentDialogCentralWidget::measureDownloadComplete(const std::st
   if (measure) {
     // good
 
-    // remove old measure
-    boost::optional<BCLMeasure> oldMeasure = OSAppBase::instance()->currentDocument()->getLocalMeasure(measure->uid());
-    if (oldMeasure && oldMeasure->versionId() != measure->versionId()) {
-      LocalBCL::instance().removeMeasure(*oldMeasure);
+    // remove old measures
+    for (auto& oldMeasure : OSAppBase::instance()->currentDocument()->getLocalMeasures()) {
+      if ((oldMeasure.uid() == measure->uid()) && (oldMeasure.versionId() != measure->versionId())) {
+        LocalBCL::instance().removeMeasure(oldMeasure);
+      }
     }
+
   } else {
     // error downloading measure
     downloadFailed(uid);

--- a/src/shared_gui_components/BuildingComponentDialogCentralWidget.cpp
+++ b/src/shared_gui_components/BuildingComponentDialogCentralWidget.cpp
@@ -286,14 +286,8 @@ void BuildingComponentDialogCentralWidget::comboBoxIndexChanged(const QString& t
 
 void BuildingComponentDialogCentralWidget::componentDownloadComplete(const std::string& uid, const boost::optional<BCLComponent>& component) {
   if (component) {
-    // good
-
-    // remove old components
-    for (auto& oldComponent : OSAppBase::instance()->currentDocument()->getLocalComponents()) {
-      if ((oldComponent.uid() == component->uid()) && (oldComponent.versionId() != component->versionId())) {
-        LocalBCL::instance().removeComponent(oldComponent);
-      }
-    }
+    // remove outdated components
+    OSAppBase::instance()->currentDocument()->removeOutdatedLocalComponents(component->uid(), component->versionId());
   } else {
     // error downloading component
     downloadFailed(uid);
@@ -306,15 +300,8 @@ void BuildingComponentDialogCentralWidget::componentDownloadComplete(const std::
 
 void BuildingComponentDialogCentralWidget::measureDownloadComplete(const std::string& uid, const boost::optional<BCLMeasure>& measure) {
   if (measure) {
-    // good
-
-    // remove old measures
-    for (auto& oldMeasure : OSAppBase::instance()->currentDocument()->getLocalMeasures()) {
-      if ((oldMeasure.uid() == measure->uid()) && (oldMeasure.versionId() != measure->versionId())) {
-        LocalBCL::instance().removeMeasure(oldMeasure);
-      }
-    }
-
+    // remove outdated measures
+    OSAppBase::instance()->currentDocument()->removeOutdatedLocalMeasures(measure->uid(), measure->versionId());
   } else {
     // error downloading measure
     downloadFailed(uid);

--- a/src/shared_gui_components/MeasureManager.cpp
+++ b/src/shared_gui_components/MeasureManager.cpp
@@ -990,7 +990,7 @@ void MeasureManager::checkForRemoteBCLUpdates() {
           OSAppBase::instance()->currentDocument()->removeOutdatedLocalMeasures(update.uid(), update.versionId());
         }
       }
-  
+
       updateMeasuresLists(false);
     }
   }

--- a/src/shared_gui_components/MeasureManager.cpp
+++ b/src/shared_gui_components/MeasureManager.cpp
@@ -981,9 +981,6 @@ void MeasureManager::checkForRemoteBCLUpdates() {
     int result = msg.exec();
     if (result == QMessageBox::Yes) {
       remoteBCL.updateMeasures();
-      for (auto& oldMeasure : oldMeasures) {
-        LocalBCL::instance().removeMeasure(oldMeasure);
-      }
       updateMeasuresLists(false);
     }
   }


### PR DESCRIPTION
Properly remove components and measures of the old version, add missing pngs to qrc, don't remove all old measures after updating measures

Fixes #696 

Behavior will be further improved with https://github.com/NREL/OpenStudio/pull/5127