### PR TITLE
Fix issues with MeasureManager

### DIFF
--- a/src/openstudio_lib/ApplyMeasureNowDialog.cpp
+++ b/src/openstudio_lib/ApplyMeasureNowDialog.cpp
@@ -53,7 +53,6 @@
 #include "../utilities/OpenStudioApplicationPathHelpers.hpp"
 
 #include <openstudio/utilities/core/PathHelpers.hpp>
-#include <openstudio/utilities/core/RubyException.hpp>
 #include <openstudio/utilities/filetypes/WorkflowJSON.hpp>
 #include <openstudio/utilities/filetypes/WorkflowStep.hpp>
 #include <openstudio/utilities/filetypes/WorkflowStepResult.hpp>
@@ -77,6 +76,7 @@
 
 #include <fstream>
 
+#define LOADING_ARG_TEXT "<FONT COLOR = BLACK>Loading Arguments..."
 #define FAILED_ARG_TEXT "<FONT COLOR = RED>Failed to Show Arguments<FONT COLOR = BLACK> <br> <br>Reason(s): <br> <br>"
 
 #define ACCEPT_CHANGES "Accept Changes"
@@ -89,6 +89,7 @@ ApplyMeasureNowDialog::ApplyMeasureNowDialog(QWidget* parent)
     m_editController(nullptr),
     m_mainPaneStackedWidget(nullptr),
     m_rightPaneStackedWidget(nullptr),
+    m_argumentsLoadingTextEdit(nullptr),
     m_argumentsFailedTextEdit(nullptr),
     m_jobItemView(nullptr),
     m_timer(nullptr),
@@ -177,6 +178,9 @@ void ApplyMeasureNowDialog::createWidgets() {
 
   // INPUT
 
+  m_argumentsLoadingTextEdit = new QTextEdit(LOADING_ARG_TEXT);
+  m_argumentsLoadingTextEdit->setReadOnly(true);
+
   m_argumentsFailedTextEdit = new QTextEdit(FAILED_ARG_TEXT);
   m_argumentsFailedTextEdit->setReadOnly(true);
 
@@ -193,6 +197,7 @@ void ApplyMeasureNowDialog::createWidgets() {
   app->currentDocument()->enable();
 
   m_rightPaneStackedWidget = new QStackedWidget();
+  m_argumentsLoadingPageIdx = m_rightPaneStackedWidget->addWidget(m_argumentsLoadingTextEdit);
   m_argumentsFailedPageIdx = m_rightPaneStackedWidget->addWidget(m_argumentsFailedTextEdit);
 
   auto* viewSwitcher = new OSViewSwitcher();
@@ -295,11 +300,16 @@ void ApplyMeasureNowDialog::resizeEvent(QResizeEvent* event) {
 }
 
 void ApplyMeasureNowDialog::displayMeasure() {
+  std::unique_lock lock(m_displayMutex, std::try_to_lock);
+  if (!lock.owns_lock()) {
+    return;
+  }  
+
   this->okButton()->setText(APPLY_MEASURE);
   this->okButton()->show();
   this->okButton()->setEnabled(false);
 
-  m_rightPaneStackedWidget->setCurrentIndex(m_argumentsOkPageIdx);
+  m_rightPaneStackedWidget->setCurrentIndex(m_argumentsLoadingPageIdx);
 
   m_bclMeasure.reset();
   m_currentMeasureStepItem.clear();
@@ -349,6 +359,7 @@ void ApplyMeasureNowDialog::displayMeasure() {
     m_currentMeasureStepItem->setDescription(m_bclMeasure->description().c_str());
 
     m_editController->setMeasureStepItem(m_currentMeasureStepItem.data(), app);
+    m_rightPaneStackedWidget->setCurrentIndex(m_argumentsOkPageIdx);
 
   } catch (const std::exception& e) {
     QString errorMessage("Failed to display measure: \n\n");

--- a/src/openstudio_lib/ApplyMeasureNowDialog.hpp
+++ b/src/openstudio_lib/ApplyMeasureNowDialog.hpp
@@ -37,6 +37,8 @@
 
 #include <openstudio/utilities/bcl/BCLMeasure.hpp>
 
+#include <mutex>
+
 class QPushButton;
 class QStackedWidget;
 class QTextEdit;
@@ -130,6 +132,8 @@ class ApplyMeasureNowDialog : public OSDialog
 
   QStackedWidget* m_rightPaneStackedWidget;
 
+  QTextEdit* m_argumentsLoadingTextEdit;
+
   QTextEdit* m_argumentsFailedTextEdit;
 
   DataPointJobItemView* m_jobItemView;
@@ -141,6 +145,8 @@ class ApplyMeasureNowDialog : public OSDialog
   int m_runningPageIdx;
 
   int m_outputPageIdx;
+
+  int m_argumentsLoadingPageIdx;
 
   int m_argumentsFailedPageIdx;
 
@@ -163,6 +169,8 @@ class ApplyMeasureNowDialog : public OSDialog
   WorkflowJSON m_modelWorkflowJSON;
 
   WorkflowJSON m_tempWorkflowJSON;
+
+  std::mutex m_displayMutex;
 };
 
 class DataPointJobHeaderView : public OSHeader

--- a/src/shared_gui_components/MeasureManager.cpp
+++ b/src/shared_gui_components/MeasureManager.cpp
@@ -47,7 +47,6 @@
 
 #include <openstudio/utilities/core/Assert.hpp>
 #include <openstudio/utilities/core/PathHelpers.hpp>
-#include <openstudio/utilities/core/RubyException.hpp>
 #include <openstudio/utilities/core/System.hpp>
 #include <openstudio/utilities/bcl/BCLMeasure.hpp>
 #include <openstudio/utilities/bcl/RemoteBCL.hpp>
@@ -371,7 +370,7 @@ std::pair<bool, std::string> MeasureManager::updateMeasure(const BCLMeasure& t_m
       result = std::pair<bool, std::string>(false, ss.str());
     }
 
-  } catch (const RubyException& e) {
+  } catch (const std::exception& e) {
     std::stringstream ss;
     ss << "An error occurred while updating measure '" << t_measure.displayName() << "':" << std::endl;
     ss << "  " << e.what();
@@ -499,7 +498,7 @@ std::vector<measure::OSArgument> MeasureManager::getArguments(const BCLMeasure& 
   Json::Value json;
   bool parsingSuccessful = Json::parseFromStream(rbuilder, ss, &json, &errorString);
 
-  if (parsingSuccessful) {
+  if (parsingSuccessful && json.type() == Json::objectValue) {
 
     Json::Value arguments = json.get("arguments", Json::Value(Json::arrayValue));
 

--- a/src/shared_gui_components/WorkflowController.cpp
+++ b/src/shared_gui_components/WorkflowController.cpp
@@ -44,7 +44,6 @@
 #include <openstudio/utilities/core/Assert.hpp>
 #include <openstudio/utilities/core/Compare.hpp>
 #include <openstudio/utilities/core/Containers.hpp>
-#include <openstudio/utilities/core/RubyException.hpp>
 #include <openstudio/utilities/core/PathHelpers.hpp>
 #include <openstudio/utilities/bcl/BCLMeasure.hpp>
 #include <openstudio/utilities/filetypes/WorkflowStep_Impl.hpp>
@@ -257,7 +256,7 @@ void MeasureStepController::addItemForDroppedMeasure(QDropEvent* event) {
   MeasureStep measureStep(toString(getLastLevelDirectoryName(projectMeasure->directory())));
   try {
     /* std::vector<measure::OSArgument> arguments = */ m_app->measureManager().getArguments(*projectMeasure);
-  } catch (const RubyException& e) {
+  } catch (const std::exception& e) {
     QString errorMessage("Failed to compute arguments for measure: \n\n");
     errorMessage += QString::fromStdString(e.what());
     QMessageBox::information(m_app->mainWidget(), QString("Failed to add measure"), errorMessage);
@@ -352,7 +351,7 @@ void MeasureStepController::moveDown(MeasureStep step) {
 
 MeasureStepItem::MeasureStepItem(MeasureType measureType, MeasureStep step, openstudio::BaseApp* t_baseApp)
   : m_measureType(measureType),
-    m_step(std::move(step)),
+    m_step(step),
     m_app(t_baseApp)
 
 {}


### PR DESCRIPTION
- Add loading tab to discourage selecting another measure which arguments for first measure are being computed (this can take a long time in failure case).  
- Catch all std::exceptions instead of just RubyExceptions which prevents crash.  Fixes #656
