### PR TITLE
Update scripts to Ruby 3.2

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -13,7 +13,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.2
 
     - uses: actions/setup-python@v5
       with:

--- a/developer/ruby/GitHubIssueStats.rb
+++ b/developer/ruby/GitHubIssueStats.rb
@@ -61,7 +61,7 @@ end
 if !ENV['GITHUB_TOKEN'].nil?
   token = ENV['GITHUB_TOKEN']
   @github = Github.new oauth_token: token
-elsif File.exists?(Dir.home + '/github_config.yml')
+elsif File.exist?(Dir.home + '/github_config.yml')
   github_options = YAML.load_file(Dir.home + '/github_config.yml')
   token = github_options['oauth_token']
   @github = Github.new oauth_token: token


### PR DESCRIPTION
Fix the release notes action by updating to Ruby 3.2

Previous run failure at https://github.com/openstudiocoalition/OpenStudioApplication/actions/runs/10219493337/job/28277862658