### PR TITLE
Fix #162 - Display ScheduleConstant, ScheduleCompact and ScheduleFile

### DIFF
--- a/src/openstudio_lib/CMakeLists.txt
+++ b/src/openstudio_lib/CMakeLists.txt
@@ -393,6 +393,7 @@ set(${target_name}_SRC
   ../shared_gui_components/CollapsibleComponentHeader.hpp
   ../shared_gui_components/CollapsibleComponentList.cpp
   ../shared_gui_components/CollapsibleComponentList.hpp
+  ../shared_gui_components/ColorPalettes.hpp
   ../shared_gui_components/Component.cpp
   ../shared_gui_components/Component.hpp
   ../shared_gui_components/ComponentList.cpp

--- a/src/openstudio_lib/CMakeLists.txt
+++ b/src/openstudio_lib/CMakeLists.txt
@@ -254,6 +254,16 @@ set(${target_name}_SRC
   SchedulesTabView.hpp
   SchedulesView.cpp
   SchedulesView.hpp
+  ScheduleOthersController.cpp
+  ScheduleOthersController.hpp
+  ScheduleOthersView.cpp
+  ScheduleOthersView.hpp
+  ScheduleConstantInspectorView.cpp
+  ScheduleConstantInspectorView.hpp
+  ScheduleCompactInspectorView.cpp
+  ScheduleCompactInspectorView.hpp
+  ScheduleFileInspectorView.cpp
+  ScheduleFileInspectorView.hpp
   ScriptItem.cpp
   ScriptItem.hpp
   ScriptsTabController.cpp
@@ -609,6 +619,11 @@ set(${target_name}_moc
   SchedulesTabController.hpp
   SchedulesTabView.hpp
   SchedulesView.hpp
+  ScheduleOthersView.hpp
+  ScheduleOthersController.hpp
+  ScheduleConstantInspectorView.hpp
+  ScheduleCompactInspectorView.hpp
+  ScheduleFileInspectorView.hpp
   ScriptItem.hpp
   ScriptsTabController.hpp
   ScriptsTabView.hpp

--- a/src/openstudio_lib/GridItem.cpp
+++ b/src/openstudio_lib/GridItem.cpp
@@ -31,11 +31,11 @@
 #include "ServiceWaterGridItems.hpp"
 #include "IconLibrary.hpp"
 #include "LoopScene.hpp"
-#include "SchedulesView.hpp"
 #include "OSDocument.hpp"
 #include "OSAppBase.hpp"
 #include "MainRightColumnController.hpp"
 #include "ModelObjectItem.hpp"
+#include "../shared_gui_components/ColorPalettes.hpp"
 
 #include <openstudio/utilities/core/Assert.hpp>
 #include <openstudio/utilities/core/Compare.hpp>
@@ -1380,11 +1380,11 @@ QColor SystemItem::plenumColor(const Handle& plenumHandle) {
   } else {
     int index = plenumIndex(plenumHandle);
     if (index < 0) {
-      color = SchedulesView::colors[0];
+      color = ColorPalettes::schedule_rules_colors[0];
     } else if (index > 12) {
-      color = SchedulesView::colors[12];
+      color = ColorPalettes::schedule_rules_colors[12];
     } else {
-      color = SchedulesView::colors[index];
+      color = ColorPalettes::schedule_rules_colors[index];
     }
 
     // DLM: Create a RenderingColor and associate it with the thermal zone?

--- a/src/openstudio_lib/IconLibrary.cpp
+++ b/src/openstudio_lib/IconLibrary.cpp
@@ -448,6 +448,7 @@ IconLibrary::IconLibrary() {
     new QPixmap(":/images/mini_icons/mini_water_cooled.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Schedule_Compact).value()] = new QPixmap(":/images/mini_icons/schedule.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Schedule_Constant).value()] = new QPixmap(":/images/mini_icons/schedule.png");
+  m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Schedule_File).value()] = new QPixmap(":/images/mini_icons/schedule.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Schedule_FixedInterval).value()] =
     new QPixmap(":/images/mini_icons/schedule.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Schedule_Ruleset).value()] = new QPixmap(":/images/mini_icons/schedule.png");

--- a/src/openstudio_lib/MainRightColumnController.cpp
+++ b/src/openstudio_lib/MainRightColumnController.cpp
@@ -319,6 +319,25 @@ void MainRightColumnController::configureForSchedulesSubTab(int subTabID) {
 
       break;
     }
+    case SchedulesTabController::SCHEDULESOTHER: {
+      model::Model lib = doc->componentLibrary();
+
+      // my library
+      auto* myLibraryList = new ModelObjectTypeListView(lib, true, OSItemType::CollapsibleListHeader, true);
+      myLibraryList->setItemsDraggable(true);
+      myLibraryList->setItemsRemoveable(false);
+      myLibraryList->setItemsType(OSItemType::LibraryItem);
+
+      myLibraryList->addModelObjectType(IddObjectType::OS_Schedule_Constant, "Constant Schedules");
+      // myLibraryList->addModelObjectType(IddObjectType::OS_Schedule_Compact, "Compact Schedules");
+      myLibraryList->addModelObjectCategoryPlaceholder("Schedules");
+
+      setLibraryView(myLibraryList);
+      doc->openSidebar();
+      //doc->closeSidebar();
+
+      break;
+    }
     default:
       break;
   }

--- a/src/openstudio_lib/ScheduleCompactInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleCompactInspectorView.cpp
@@ -91,8 +91,7 @@ void ScheduleCompactInspectorView::createLayout() {
 
   m_content = new QPlainTextEdit();
   m_content->setReadOnly(true);
-  QFont f("monospace");
-  f.setStyleHint(QFont::Monospace);
+  const QFont f = QFontDatabase::systemFont(QFontDatabase::FixedFont);
   m_content->setFont(f);
 
   mainGridLayout->addWidget(m_content, row++, 0, 1, 2);

--- a/src/openstudio_lib/ScheduleCompactInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleCompactInspectorView.cpp
@@ -1,0 +1,150 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2020-2023, OpenStudio Coalition and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include "ScheduleCompactInspectorView.hpp"
+
+#include "../shared_gui_components/OSLineEdit.hpp"
+#include "../shared_gui_components/OSDoubleEdit.hpp"
+#include "../model_editor/Utilities.hpp"
+
+#include <openstudio/model/ScheduleCompact.hpp>
+#include <openstudio/model/ScheduleCompact_Impl.hpp>
+
+#include <openstudio/utilities/core/Assert.hpp>
+
+#include <QGridLayout>
+#include <QLabel>
+#include <QStackedWidget>
+#include <QPlainTextEdit>
+
+#include <sstream>
+
+namespace openstudio {
+
+// ScheduleCompactInspectorView
+
+ScheduleCompactInspectorView::ScheduleCompactInspectorView(const openstudio::model::Model& model, QWidget* parent)
+  : ModelObjectInspectorView(model, true, parent) {
+  createLayout();
+}
+
+void ScheduleCompactInspectorView::createLayout() {
+  auto* hiddenWidget = new QWidget();
+  this->stackedWidget()->addWidget(hiddenWidget);
+
+  auto* visibleWidget = new QWidget();
+  this->stackedWidget()->addWidget(visibleWidget);
+
+  auto* mainGridLayout = new QGridLayout();
+  mainGridLayout->setContentsMargins(7, 7, 7, 7);
+  mainGridLayout->setSpacing(14);
+  visibleWidget->setLayout(mainGridLayout);
+
+  int row = mainGridLayout->rowCount();
+
+  QLabel* label = nullptr;
+
+  // Name
+
+  label = new QLabel("Name: ");
+  label->setObjectName("H2");
+  mainGridLayout->addWidget(label, row, 0);
+
+  ++row;
+
+  m_nameEdit = new OSLineEdit2();
+  mainGridLayout->addWidget(m_nameEdit, row, 0, 1, 1);
+
+  ++row;
+
+  // Value
+
+  label = new QLabel("Content: ");
+  label->setObjectName("H2");
+  mainGridLayout->addWidget(label, row++, 0);
+
+  m_content = new QPlainTextEdit();
+  m_content->setReadOnly(true);
+  QFont f("monospace");
+  f.setStyleHint(QFont::Monospace);
+  m_content->setFont(f);
+
+  mainGridLayout->addWidget(m_content, row++, 0, 1, 2);
+
+  // Stretch
+
+  mainGridLayout->setRowStretch(100, 100);
+  mainGridLayout->setColumnStretch(0, 3);
+  mainGridLayout->setColumnStretch(1, 1);
+  mainGridLayout->setColumnStretch(2, 1);
+}
+
+void ScheduleCompactInspectorView::onClearSelection() {
+  ModelObjectInspectorView::onClearSelection();  // call parent implementation
+  detach();
+}
+
+void ScheduleCompactInspectorView::onSelectModelObject(const openstudio::model::ModelObject& modelObject) {
+  detach();
+  auto sch = modelObject.cast<model::ScheduleCompact>();
+  attach(sch);
+  refresh();
+}
+
+void ScheduleCompactInspectorView::onUpdate() {
+  refresh();
+}
+
+void ScheduleCompactInspectorView::attach(openstudio::model::ScheduleCompact& sch) {
+  m_sch = sch;
+
+  m_nameEdit->bind(
+    *m_sch, OptionalStringGetter(std::bind(&model::ScheduleCompact::name, m_sch.get_ptr(), true)),
+    boost::optional<StringSetterOptionalStringReturn>(std::bind(&model::ScheduleCompact::setName, m_sch.get_ptr(), std::placeholders::_1)));
+
+  std::stringstream ss;
+  sch.print(ss);
+
+  m_content->setPlainText(toQString(ss.str()));
+
+  this->stackedWidget()->setCurrentIndex(1);
+}
+
+void ScheduleCompactInspectorView::detach() {
+  this->stackedWidget()->setCurrentIndex(0);
+
+  m_nameEdit->unbind();
+
+  m_sch = boost::none;
+}
+
+void ScheduleCompactInspectorView::refresh() {}
+
+}  // namespace openstudio
+

--- a/src/openstudio_lib/ScheduleCompactInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleCompactInspectorView.cpp
@@ -146,4 +146,3 @@ void ScheduleCompactInspectorView::detach() {
 void ScheduleCompactInspectorView::refresh() {}
 
 }  // namespace openstudio
-

--- a/src/openstudio_lib/ScheduleCompactInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleCompactInspectorView.hpp
@@ -44,7 +44,7 @@ class ScheduleCompactInspectorView : public ModelObjectInspectorView
   Q_OBJECT
 
  public:
-  ScheduleCompactInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
+  explicit ScheduleCompactInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
 
   virtual ~ScheduleCompactInspectorView() = default;
 

--- a/src/openstudio_lib/ScheduleCompactInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleCompactInspectorView.hpp
@@ -27,110 +27,50 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#ifndef OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
-#define OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#ifndef OPENSTUDIO_SCHEDULECOMPACTINSPECTORVIEW_HPP
+#define OPENSTUDIO_SCHEDULECOMPACTINSPECTORVIEW_HPP
 
-#include "MainTabController.hpp"
+#include "ModelObjectInspectorView.hpp"
+#include <openstudio/model/ScheduleCompact.hpp>
 
-#include <openstudio/model/Model.hpp>
-#include <openstudio/model/ScheduleRuleset.hpp>
-#include <openstudio/model/ScheduleRuleset_Impl.hpp>
-
-#include <openstudio/utilities/core/UUID.hpp>
-
-#include <boost/smart_ptr.hpp>
-
-#include <QObject>
+class QPlainTextEdit;
 
 namespace openstudio {
 
-class OSItemId;
+class OSLineEdit2;
 
-namespace model {
-
-class ScheduleCompact;
-
-}
-
-class DayScheduleScene;
-
-class MainTabView;
-
-class ScheduleDialog;
-
-class ScheduleSetsController;
-
-class SchedulesView;
-
-class SchedulesTabController : public MainTabController
+class ScheduleCompactInspectorView : public ModelObjectInspectorView
 {
   Q_OBJECT
 
  public:
-  SchedulesTabController(bool isIP, const model::Model& model);
+  ScheduleCompactInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
 
-  virtual ~SchedulesTabController();
+  virtual ~ScheduleCompactInspectorView() = default;
 
-  enum TabID
-  {
-    //YEAR_SETTINGS,
-    SCHEDULE_SETS,
-    SCHEDULES,
-    SCHEDULESOTHER
-  };
+ protected:
+  virtual void onClearSelection() override;
 
-  static double defaultStartingValue(const model::ScheduleDay& scheduleDay);
+  virtual void onSelectModelObject(const openstudio::model::ModelObject& modelObject) override;
+
+  virtual void onUpdate() override;
 
  private:
-  void showScheduleDialog();
+  void createLayout();
 
-  ScheduleDialog* m_scheduleDialog = nullptr;
+  void attach(openstudio::model::ScheduleCompact& sch);
 
-  model::Model m_model;
+  void detach();
 
-  bool m_isIP;
+  void refresh();
 
-  QWidget* m_currentView = nullptr;
+  boost::optional<model::ScheduleCompact> m_sch;
 
-  QObject* m_currentController = nullptr;
+  OSLineEdit2* m_nameEdit = nullptr;
 
-  int m_currentIndex = -1;
-
- public slots:
-
-  virtual void setSubTab(int index) override;
-
-  void toggleUnits(bool displayIP);
-
- private slots:
-
-  void addScheduleRuleset();
-
-  void copySelectedSchedule();
-
-  void removeSelectedSchedule();
-
-  void purgeUnusedScheduleRulesets();
-
-  void addRule(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addSummerProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addWinterProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addHolidayProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void removeScheduleRule(model::ScheduleRule& scheduleRule);
-
-  void onDayScheduleSceneChanged(DayScheduleScene* scene, double lowerLimitValue, double upperLimitValue);
-
-  void onStartDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onEndDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onItemDropped(const OSItemId& itemId);
+  QPlainTextEdit* m_content = nullptr;
 };
 
 }  // namespace openstudio
 
-#endif  // OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#endif  // OPENSTUDIO_SCHEDULECOMPACTINSPECTORVIEW_HPP

--- a/src/openstudio_lib/ScheduleConstantInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleConstantInspectorView.cpp
@@ -142,4 +142,3 @@ void ScheduleConstantInspectorView::detach() {
 void ScheduleConstantInspectorView::refresh() {}
 
 }  // namespace openstudio
-

--- a/src/openstudio_lib/ScheduleConstantInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleConstantInspectorView.cpp
@@ -1,0 +1,145 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2020-2023, OpenStudio Coalition and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include "ScheduleConstantInspectorView.hpp"
+
+#include "../shared_gui_components/OSLineEdit.hpp"
+#include "../shared_gui_components/OSDoubleEdit.hpp"
+
+#include <openstudio/model/ScheduleConstant.hpp>
+#include <openstudio/model/ScheduleConstant_Impl.hpp>
+
+#include <openstudio/utilities/core/Assert.hpp>
+
+#include <QGridLayout>
+#include <QLabel>
+#include <QStackedWidget>
+
+namespace openstudio {
+
+// ScheduleConstantInspectorView
+
+ScheduleConstantInspectorView::ScheduleConstantInspectorView(const openstudio::model::Model& model, QWidget* parent)
+  : ModelObjectInspectorView(model, true, parent) {
+  createLayout();
+}
+
+void ScheduleConstantInspectorView::createLayout() {
+  auto* hiddenWidget = new QWidget();
+  this->stackedWidget()->addWidget(hiddenWidget);
+
+  auto* visibleWidget = new QWidget();
+  this->stackedWidget()->addWidget(visibleWidget);
+
+  auto* mainGridLayout = new QGridLayout();
+  mainGridLayout->setContentsMargins(7, 7, 7, 7);
+  mainGridLayout->setSpacing(14);
+  visibleWidget->setLayout(mainGridLayout);
+
+  int row = mainGridLayout->rowCount();
+
+  QLabel* label = nullptr;
+
+  // Name
+
+  label = new QLabel("Name: ");
+  label->setObjectName("H2");
+  mainGridLayout->addWidget(label, row, 0);
+
+  ++row;
+
+  m_nameEdit = new OSLineEdit2();
+  mainGridLayout->addWidget(m_nameEdit, row, 0, 1, 2);
+
+  ++row;
+
+  // Value
+
+  label = new QLabel(" Value: ");
+  label->setObjectName("H2");
+  mainGridLayout->addWidget(label, row++, 0);
+
+  m_value = new OSDoubleEdit2();
+  mainGridLayout->addWidget(m_value, row++, 0, 1, 1);
+
+  // Stretch
+
+  mainGridLayout->setRowStretch(100, 100);
+
+  mainGridLayout->setColumnStretch(0, 1);
+  mainGridLayout->setColumnStretch(1, 1);
+  mainGridLayout->setColumnStretch(2, 1);
+}
+
+void ScheduleConstantInspectorView::onClearSelection() {
+  ModelObjectInspectorView::onClearSelection();  // call parent implementation
+  detach();
+}
+
+void ScheduleConstantInspectorView::onSelectModelObject(const openstudio::model::ModelObject& modelObject) {
+  detach();
+  auto sch = modelObject.cast<model::ScheduleConstant>();
+  attach(sch);
+  refresh();
+}
+
+void ScheduleConstantInspectorView::onUpdate() {
+  refresh();
+}
+
+void ScheduleConstantInspectorView::attach(openstudio::model::ScheduleConstant& sch) {
+  m_sch = sch;
+
+  // m_nameEdit->bind(sch,"name");
+  m_nameEdit->bind(
+    *m_sch, OptionalStringGetter(std::bind(&model::ScheduleConstant::name, m_sch.get_ptr(), true)),
+    boost::optional<StringSetterOptionalStringReturn>(std::bind(&model::ScheduleConstant::setName, m_sch.get_ptr(), std::placeholders::_1)));
+
+  // m_value->bind(sch,"value",m_isIP);
+  m_value->bind(*m_sch, DoubleGetter(std::bind(&model::ScheduleConstant::value, m_sch.get_ptr())),
+                //static_cast<void(Client::*)(int)>(&Client::foobar)
+                boost::optional<DoubleSetter>(std::bind(static_cast<bool (model::ScheduleConstant::*)(double)>(&model::ScheduleConstant::setValue),
+                                                        m_sch.get_ptr(), std::placeholders::_1)));
+
+  this->stackedWidget()->setCurrentIndex(1);
+}
+
+void ScheduleConstantInspectorView::detach() {
+  this->stackedWidget()->setCurrentIndex(0);
+
+  m_nameEdit->unbind();
+  m_value->unbind();
+
+  m_sch = boost::none;
+}
+
+void ScheduleConstantInspectorView::refresh() {}
+
+}  // namespace openstudio
+

--- a/src/openstudio_lib/ScheduleConstantInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleConstantInspectorView.hpp
@@ -44,7 +44,7 @@ class ScheduleConstantInspectorView : public ModelObjectInspectorView
   Q_OBJECT
 
  public:
-  ScheduleConstantInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
+  explicit ScheduleConstantInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
 
   virtual ~ScheduleConstantInspectorView() = default;
 

--- a/src/openstudio_lib/ScheduleConstantInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleConstantInspectorView.hpp
@@ -27,110 +27,50 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#ifndef OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
-#define OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#ifndef OPENSTUDIO_SCHEDULECONSTANTINSPECTORVIEW_HPP
+#define OPENSTUDIO_SCHEDULECONSTANTINSPECTORVIEW_HPP
 
-#include "MainTabController.hpp"
-
-#include <openstudio/model/Model.hpp>
-#include <openstudio/model/ScheduleRuleset.hpp>
-#include <openstudio/model/ScheduleRuleset_Impl.hpp>
-
-#include <openstudio/utilities/core/UUID.hpp>
-
-#include <boost/smart_ptr.hpp>
-
-#include <QObject>
+#include "ModelObjectInspectorView.hpp"
+#include <openstudio/model/ScheduleConstant.hpp>
 
 namespace openstudio {
 
-class OSItemId;
+class OSLineEdit2;
 
-namespace model {
+class OSDoubleEdit2;
 
-class ScheduleCompact;
-
-}
-
-class DayScheduleScene;
-
-class MainTabView;
-
-class ScheduleDialog;
-
-class ScheduleSetsController;
-
-class SchedulesView;
-
-class SchedulesTabController : public MainTabController
+class ScheduleConstantInspectorView : public ModelObjectInspectorView
 {
   Q_OBJECT
 
  public:
-  SchedulesTabController(bool isIP, const model::Model& model);
+  ScheduleConstantInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
 
-  virtual ~SchedulesTabController();
+  virtual ~ScheduleConstantInspectorView() = default;
 
-  enum TabID
-  {
-    //YEAR_SETTINGS,
-    SCHEDULE_SETS,
-    SCHEDULES,
-    SCHEDULESOTHER
-  };
+ protected:
+  virtual void onClearSelection() override;
 
-  static double defaultStartingValue(const model::ScheduleDay& scheduleDay);
+  virtual void onSelectModelObject(const openstudio::model::ModelObject& modelObject) override;
+
+  virtual void onUpdate() override;
 
  private:
-  void showScheduleDialog();
+  void createLayout();
 
-  ScheduleDialog* m_scheduleDialog = nullptr;
+  void attach(openstudio::model::ScheduleConstant& sch);
 
-  model::Model m_model;
+  void detach();
 
-  bool m_isIP;
+  void refresh();
 
-  QWidget* m_currentView = nullptr;
+  boost::optional<model::ScheduleConstant> m_sch;
 
-  QObject* m_currentController = nullptr;
+  OSLineEdit2* m_nameEdit = nullptr;
 
-  int m_currentIndex = -1;
-
- public slots:
-
-  virtual void setSubTab(int index) override;
-
-  void toggleUnits(bool displayIP);
-
- private slots:
-
-  void addScheduleRuleset();
-
-  void copySelectedSchedule();
-
-  void removeSelectedSchedule();
-
-  void purgeUnusedScheduleRulesets();
-
-  void addRule(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addSummerProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addWinterProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addHolidayProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void removeScheduleRule(model::ScheduleRule& scheduleRule);
-
-  void onDayScheduleSceneChanged(DayScheduleScene* scene, double lowerLimitValue, double upperLimitValue);
-
-  void onStartDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onEndDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onItemDropped(const OSItemId& itemId);
+  OSDoubleEdit2* m_value = nullptr;
 };
 
 }  // namespace openstudio
 
-#endif  // OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#endif  // OPENSTUDIO_SCHEDULECONSTANTINSPECTORVIEW_HPP

--- a/src/openstudio_lib/ScheduleFileInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.cpp
@@ -282,16 +282,14 @@ void ScheduleFileInspectorView::attach(openstudio::model::ScheduleFile& sch) {
     std::bind(&model::ScheduleFile::columnSeparator, m_sch.get_ptr()),
     std::bind(&model::ScheduleFile::setColumnSeparator, m_sch.get_ptr(), std::placeholders::_1), boost::none, boost::none);
 
-  /*
-  m_minutesperItem->bind<std::string>(*m_sch, static_cast<std::string (*)(const std::string&)>(&openstudio::toString),
-                                      &model::ScheduleFile::minutesperItemValues,
-                                      OptionalStringGetter(std::bind(&model::ScheduleFile::minutesperItem, m_sch.get_ptr())),
-                                      std::bind(&model::ScheduleFile::setColumnSeparator, m_sch.get_ptr(), std::placeholders::_1),
-                                      boost::optional<NoFailAction>(std::bind(&model::ScheduleFile::resetMinutesperItem, m_sch.get_ptr())),
-                                      boost::optional<BasicQuery>(std::bind(&model::ScheduleFile::isMinutesperItemDefaulted, m_sch.get_ptr()))
+  m_minutesperItem->bind<std::string>(
+    *m_sch, static_cast<std::string (*)(const std::string&)>(&openstudio::toString), &model::ScheduleFile::minutesperItemValues,
+    OptionalStringGetter(std::bind(&model::ScheduleFile::minutesperItem, m_sch.get_ptr())),
+    boost::optional<StringSetter>(std::bind(&model::ScheduleFile::setColumnSeparator, m_sch.get_ptr(), std::placeholders::_1)),
+    boost::optional<NoFailAction>(std::bind(&model::ScheduleFile::resetMinutesperItem, m_sch.get_ptr())),
+    boost::optional<BasicQuery>(std::bind(&model::ScheduleFile::isMinutesperItemDefaulted, m_sch.get_ptr()))
 
   );
-  */
 
   // OSSwitch2
 
@@ -327,7 +325,7 @@ void ScheduleFileInspectorView::detach() {
   m_numberofHoursofData->unbind();
   m_columnSeparator->unbind();
   m_interpolatetoTimestep->unbind();
-  // m_minutesperItem->unbind();
+  m_minutesperItem->unbind();
   m_adjustScheduleforDaylightSavings->unbind();
   m_translateFileWithRelativePath->unbind();
 

--- a/src/openstudio_lib/ScheduleFileInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.cpp
@@ -349,7 +349,14 @@ void ScheduleFileInspectorView::attach(openstudio::model::ScheduleFile& sch) {
     // ScheduleFile::columnSeparatorValues does not exist: https://github.com/NREL/OpenStudio/issues/5246
     []() { return std::vector<std::string>{"Comma", "Tab", "Space", "Semicolon"}; },
     std::bind(&model::ScheduleFile::columnSeparator, m_sch.get_ptr()),
-    std::bind(&model::ScheduleFile::setColumnSeparator, m_sch.get_ptr(), std::placeholders::_1), boost::none, boost::none);
+    [this](const std::string& value) -> bool {
+      bool result = m_sch->setColumnSeparator(value);
+      if (result) {
+        refreshContent();
+      }
+      return result;
+    },
+    boost::none, boost::none);
 
   m_minutesperItem->bind<std::string>(
     *m_sch,

--- a/src/openstudio_lib/ScheduleFileInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.cpp
@@ -155,7 +155,6 @@ void ScheduleFileInspectorView::createLayout() {
   m_columnSeparator = new OSComboBox2();
   m_columnSeparator->addItem("Comma");
   m_columnSeparator->addItem("Tab");
-  m_columnSeparator->addItem("Fixed");
   m_columnSeparator->addItem("Space");
   m_columnSeparator->addItem("Semicolon");
   m_columnSeparator->setEnabled(true);
@@ -339,7 +338,7 @@ void ScheduleFileInspectorView::attach(openstudio::model::ScheduleFile& sch) {
   m_columnSeparator->bind<std::string>(
     *m_sch, static_cast<std::string (*)(const std::string&)>(&openstudio::toString),
     // ScheduleFile::columnSeparatorValues does not exist: https://github.com/NREL/OpenStudio/issues/5246
-    []() { return std::vector<std::string>{"Comma", "Tab", "Fixed", "Space", "Semicolon"}; },
+    []() { return std::vector<std::string>{"Comma", "Tab", "Space", "Semicolon"}; },
     std::bind(&model::ScheduleFile::columnSeparator, m_sch.get_ptr()),
     std::bind(&model::ScheduleFile::setColumnSeparator, m_sch.get_ptr(), std::placeholders::_1), boost::none, boost::none);
 

--- a/src/openstudio_lib/ScheduleFileInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.cpp
@@ -49,6 +49,7 @@
 #include <QFile>
 #include <QTextStream>
 #include <QPlainTextEdit>
+#include <QPushButton>
 
 namespace openstudio {
 
@@ -238,7 +239,27 @@ void ScheduleFileInspectorView::createLayout() {
 
   m_numLines = new QLineEdit();
   m_numLines->setReadOnly(true);
-  mainGridLayout->addWidget(m_numLines, row, 1, 1, 2);
+  mainGridLayout->addWidget(m_numLines, row, 1, 1, 1);
+
+  ++row;
+
+  label = new QLabel("Display All File Content: ");
+  label->setObjectName("H3");
+  mainGridLayout->addWidget(label, row, 0);
+
+  // Mimic an OSSwitch2
+  m_displayAllContentSwitch = new QPushButton();
+  m_displayAllContentSwitch->setAcceptDrops(false);
+  m_displayAllContentSwitch->setFlat(true);
+  m_displayAllContentSwitch->setFixedSize(63, 21);
+  m_displayAllContentSwitch->setObjectName("OnOffSliderButton");
+  m_displayAllContentSwitch->setCheckable(true);
+  mainGridLayout->addWidget(m_displayAllContentSwitch, row, 1, 1, 1);
+
+  connect(m_displayAllContentSwitch, &QPushButton::toggled, [this](bool) {
+    m_displayAllContent = !m_displayAllContent;
+    refreshContent();
+  });
 
   ++row;
 
@@ -403,7 +424,7 @@ void ScheduleFileInspectorView::refreshContent() {
     for (const QString& line : m_lines) {
       if (curLine < rowstoSkipatTop) {
         m_contentLines->appendHtml(QString("<span style='color: gray'>%1</span>").arg(line));
-      } else if (curLine < read_n_lines) {
+      } else if (m_displayAllContent || (curLine < read_n_lines)) {
         m_contentLines->appendHtml(QString("<span style='color: green'>%1</span>").arg(line));
       } else if (curLine == read_n_lines) {
         m_contentLines->appendHtml("<strong>[...]</strong>");

--- a/src/openstudio_lib/ScheduleFileInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.cpp
@@ -1,0 +1,323 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2020-2023, OpenStudio Coalition and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include "ScheduleFileInspectorView.hpp"
+
+#include "../shared_gui_components/OSLineEdit.hpp"
+#include "../shared_gui_components/OSIntegerEdit.hpp"
+#include "../shared_gui_components/OSComboBox.hpp"
+#include "../shared_gui_components/OSSwitch.hpp"
+#include "../model_editor/Utilities.hpp"
+
+#include <openstudio/model/ScheduleFile.hpp>
+#include <openstudio/model/ScheduleFile_Impl.hpp>
+#include <openstudio/model/ExternalFile.hpp>
+
+#include <openstudio/utilities/core/Assert.hpp>
+
+#include <QGridLayout>
+#include <QLabel>
+#include <QStackedWidget>
+#include <QLineEdit>
+
+namespace openstudio {
+
+// ScheduleFileInspectorView
+
+ScheduleFileInspectorView::ScheduleFileInspectorView(const openstudio::model::Model& model, QWidget* parent)
+  : ModelObjectInspectorView(model, true, parent) {
+  createLayout();
+}
+
+void ScheduleFileInspectorView::createLayout() {
+  auto* hiddenWidget = new QWidget();
+  this->stackedWidget()->addWidget(hiddenWidget);
+
+  auto* visibleWidget = new QWidget();
+  this->stackedWidget()->addWidget(visibleWidget);
+
+  auto* mainGridLayout = new QGridLayout();
+  mainGridLayout->setContentsMargins(7, 7, 7, 7);
+  mainGridLayout->setSpacing(14);
+  visibleWidget->setLayout(mainGridLayout);
+
+  int row = mainGridLayout->rowCount();
+
+  QLabel* label = nullptr;
+
+  // Name
+
+  label = new QLabel("Name: ");
+  label->setObjectName("H2");
+  mainGridLayout->addWidget(label, row, 0);
+
+  ++row;
+
+  m_nameEdit = new OSLineEdit2();
+  mainGridLayout->addWidget(m_nameEdit, row, 0, 1, 3);
+
+  // FilePath
+  ++row;
+
+  label = new QLabel("FilePath: ");
+  label->setObjectName("H2");
+  mainGridLayout->addWidget(label, row, 0);
+
+  ++row;
+
+  m_filePath = new QLineEdit();
+  m_filePath->setReadOnly(true);
+  mainGridLayout->addWidget(m_filePath, row, 0, 1, 3);
+
+  ++row;
+
+  QVBoxLayout* vLayout = nullptr;
+
+  // Column Number
+  vLayout = new QVBoxLayout();
+
+  label = new QLabel("Column Number: ");
+  label->setObjectName("H2");
+  vLayout->addWidget(label);
+
+  m_columnNumber = new OSIntegerEdit2();
+  vLayout->addWidget(m_columnNumber);
+
+  mainGridLayout->addLayout(vLayout, row, 0);
+
+  // Rows to Skip
+  vLayout = new QVBoxLayout();
+
+  label = new QLabel("Rows to Skip at Top: ");
+  label->setObjectName("H2");
+  vLayout->addWidget(label);
+
+  m_rowstoSkipatTop = new OSIntegerEdit2();
+  vLayout->addWidget(m_rowstoSkipatTop);
+
+  mainGridLayout->addLayout(vLayout, row, 1);
+
+  ++row;
+
+  // Number of Hours of Data
+  vLayout = new QVBoxLayout();
+
+  label = new QLabel("Number of Hours of Data: ");
+  label->setObjectName("H2");
+  vLayout->addWidget(label);
+
+  m_numberofHoursofData = new OSIntegerEdit2();
+  vLayout->addWidget(m_numberofHoursofData);
+
+  mainGridLayout->addLayout(vLayout, row, 0);
+
+  // Column Separator
+  vLayout = new QVBoxLayout();
+
+  label = new QLabel("Column Separator: ");
+  label->setObjectName("H2");
+  vLayout->addWidget(label);
+
+  m_columnSeparator = new OSComboBox2();
+  m_columnSeparator->addItem("Comma");
+  m_columnSeparator->addItem("Tab");
+  m_columnSeparator->addItem("Fixed");
+  m_columnSeparator->addItem("Space");
+  m_columnSeparator->addItem("Semicolon");
+  vLayout->addWidget(m_columnSeparator);
+
+  mainGridLayout->addLayout(vLayout, row, 1);
+
+  ++row;
+
+  // Interpolate
+  vLayout = new QVBoxLayout();
+
+  label = new QLabel("Interpolate to Timestep: ");
+  label->setObjectName("H2");
+  vLayout->addWidget(label);
+
+  m_interpolatetoTimestep = new OSSwitch2();
+  vLayout->addWidget(m_interpolatetoTimestep);
+
+  mainGridLayout->addLayout(vLayout, row, 0);
+
+  // Minutes per Item
+  vLayout = new QVBoxLayout();
+
+  label = new QLabel("Minutes per Item: ");
+  label->setObjectName("H2");
+  vLayout->addWidget(label);
+
+  m_minutesperItem = new OSComboBox2();
+  for (const auto& val : model::ScheduleFile::minutesperItemValues()) {
+    m_minutesperItem->addItem(QString::fromStdString(val));
+  }
+  vLayout->addWidget(m_minutesperItem);
+
+  mainGridLayout->addLayout(vLayout, row, 1);
+
+  ++row;
+
+  // Adjust Schedule for Daylight Savings
+  vLayout = new QVBoxLayout();
+
+  label = new QLabel("Adjust Schedule for Daylight Savings: ");
+  label->setObjectName("H2");
+  vLayout->addWidget(label);
+
+  m_adjustScheduleforDaylightSavings = new OSSwitch2();
+  vLayout->addWidget(m_adjustScheduleforDaylightSavings);
+
+  mainGridLayout->addLayout(vLayout, row, 0);
+
+  // Translate File With Relative Path
+  vLayout = new QVBoxLayout();
+
+  label = new QLabel("Translate File With Relative Path: ");
+  label->setObjectName("H2");
+  vLayout->addWidget(label);
+
+  m_translateFileWithRelativePath = new OSSwitch2();
+  vLayout->addWidget(m_translateFileWithRelativePath);
+
+  mainGridLayout->addLayout(vLayout, row, 1);
+
+  ++row;
+
+  // Stretch
+
+  mainGridLayout->setRowStretch(100, 100);
+
+  mainGridLayout->setColumnStretch(100, 100);
+}
+
+void ScheduleFileInspectorView::onClearSelection() {
+  ModelObjectInspectorView::onClearSelection();  // call parent implementation
+  detach();
+}
+
+void ScheduleFileInspectorView::onSelectModelObject(const openstudio::model::ModelObject& modelObject) {
+  detach();
+  auto sch = modelObject.cast<model::ScheduleFile>();
+  attach(sch);
+  refresh();
+}
+
+void ScheduleFileInspectorView::onUpdate() {
+  refresh();
+}
+
+void ScheduleFileInspectorView::attach(openstudio::model::ScheduleFile& sch) {
+  m_sch = sch;
+
+  // m_nameEdit->bind(sch,"name");
+  m_nameEdit->bind(
+    *m_sch, OptionalStringGetter(std::bind(&model::ScheduleFile::name, m_sch.get_ptr(), true)),
+    boost::optional<StringSetterOptionalStringReturn>(std::bind(&model::ScheduleFile::setName, m_sch.get_ptr(), std::placeholders::_1)));
+
+  // OSIntegerEdit2
+  m_columnNumber->bind(*m_sch, IntGetter(std::bind(&model::ScheduleFile::columnNumber, m_sch.get_ptr())),
+                       boost::optional<IntSetter>(std::bind(&model::ScheduleFile::setColumnNumber, m_sch.get_ptr(), std::placeholders::_1)));
+
+  m_rowstoSkipatTop->bind(*m_sch, IntGetter(std::bind(&model::ScheduleFile::rowstoSkipatTop, m_sch.get_ptr())),
+                          boost::optional<IntSetter>(std::bind(&model::ScheduleFile::setRowstoSkipatTop, m_sch.get_ptr(), std::placeholders::_1)));
+
+  m_numberofHoursofData->bind(
+    *m_sch, OptionalIntGetter(std::bind(&model::ScheduleFile::numberofHoursofData, m_sch.get_ptr())),
+    boost::optional<IntSetter>(std::bind(&model::ScheduleFile::setNumberofHoursofData, m_sch.get_ptr(), std::placeholders::_1)));
+
+  // OSComboBox2
+
+  m_columnSeparator->bind<std::string>(
+    *m_sch, static_cast<std::string (*)(const std::string&)>(&openstudio::toString),
+    // ScheduleFile::columnSeparatorValues does not exist: https://github.com/NREL/OpenStudio/issues/5246
+    []() {
+      return std::vector<std::string>{"Comma", "Tab", "Fixed", "Space", "Semicolon"};
+    },
+    std::bind(&model::ScheduleFile::columnSeparator, m_sch.get_ptr()),
+    std::bind(&model::ScheduleFile::setColumnSeparator, m_sch.get_ptr(), std::placeholders::_1), boost::none, boost::none);
+
+  /*
+  m_minutesperItem->bind<std::string>(*m_sch, static_cast<std::string (*)(const std::string&)>(&openstudio::toString),
+                                      &model::ScheduleFile::minutesperItemValues,
+                                      OptionalStringGetter(std::bind(&model::ScheduleFile::minutesperItem, m_sch.get_ptr())),
+                                      std::bind(&model::ScheduleFile::setColumnSeparator, m_sch.get_ptr(), std::placeholders::_1),
+                                      boost::optional<NoFailAction>(std::bind(&model::ScheduleFile::resetMinutesperItem, m_sch.get_ptr())),
+                                      boost::optional<BasicQuery>(std::bind(&model::ScheduleFile::isMinutesperItemDefaulted, m_sch.get_ptr()))
+
+  );
+  */
+
+  // OSSwitch2
+
+  m_interpolatetoTimestep->bind(
+    *m_sch, std::bind(&model::ScheduleFile::interpolatetoTimestep, m_sch.get_ptr()),
+    boost::optional<BoolSetter>(std::bind(&model::ScheduleFile::setInterpolatetoTimestep, m_sch.get_ptr(), std::placeholders::_1)),
+    boost::optional<NoFailAction>(std::bind(&model::ScheduleFile::resetInterpolatetoTimestep, m_sch.get_ptr())),
+    boost::optional<BasicQuery>(std::bind(&model::ScheduleFile::isInterpolatetoTimestepDefaulted, m_sch.get_ptr())));
+
+  m_adjustScheduleforDaylightSavings->bind(
+    *m_sch, std::bind(&model::ScheduleFile::adjustScheduleforDaylightSavings, m_sch.get_ptr()),
+    boost::optional<BoolSetter>(std::bind(&model::ScheduleFile::setAdjustScheduleforDaylightSavings, m_sch.get_ptr(), std::placeholders::_1)),
+    boost::optional<NoFailAction>(std::bind(&model::ScheduleFile::resetAdjustScheduleforDaylightSavings, m_sch.get_ptr())),
+    boost::optional<BasicQuery>(std::bind(&model::ScheduleFile::isAdjustScheduleforDaylightSavingsDefaulted, m_sch.get_ptr())));
+
+  m_translateFileWithRelativePath->bind(
+    *m_sch, std::bind(&model::ScheduleFile::translateFileWithRelativePath, m_sch.get_ptr()),
+    boost::optional<BoolSetter>(std::bind(&model::ScheduleFile::setTranslateFileWithRelativePath, m_sch.get_ptr(), std::placeholders::_1)),
+    boost::optional<NoFailAction>(std::bind(&model::ScheduleFile::resetTranslateFileWithRelativePath, m_sch.get_ptr())),
+    boost::optional<BasicQuery>(std::bind(&model::ScheduleFile::isTranslateFileWithRelativePathDefaulted, m_sch.get_ptr())));
+
+  // QLineEdit
+  m_filePath->setText(toQString(m_sch->externalFile().fileName()));
+
+  this->stackedWidget()->setCurrentIndex(1);
+}
+
+void ScheduleFileInspectorView::detach() {
+  this->stackedWidget()->setCurrentIndex(0);
+
+  m_nameEdit->unbind();
+  m_columnNumber->unbind();
+  m_rowstoSkipatTop->unbind();
+  m_numberofHoursofData->unbind();
+  m_columnSeparator->unbind();
+  m_interpolatetoTimestep->unbind();
+  // m_minutesperItem->unbind();
+  m_adjustScheduleforDaylightSavings->unbind();
+  m_translateFileWithRelativePath->unbind();
+
+  m_sch = boost::none;
+}
+
+void ScheduleFileInspectorView::refresh() {}
+
+}  // namespace openstudio
+

--- a/src/openstudio_lib/ScheduleFileInspectorView.cpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.cpp
@@ -347,7 +347,9 @@ void ScheduleFileInspectorView::attach(openstudio::model::ScheduleFile& sch) {
   m_columnSeparator->bind<std::string>(
     *m_sch, static_cast<std::string (*)(const std::string&)>(&openstudio::toString),
     // ScheduleFile::columnSeparatorValues does not exist: https://github.com/NREL/OpenStudio/issues/5246
-    []() { return std::vector<std::string>{"Comma", "Tab", "Space", "Semicolon"}; },
+    []() {
+      return std::vector<std::string>{"Comma", "Tab", "Space", "Semicolon"};
+    },
     std::bind(&model::ScheduleFile::columnSeparator, m_sch.get_ptr()),
     [this](const std::string& value) -> bool {
       bool result = m_sch->setColumnSeparator(value);

--- a/src/openstudio_lib/ScheduleFileInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.hpp
@@ -34,6 +34,7 @@
 #include <openstudio/model/ScheduleFile.hpp>
 
 class QLineEdit;
+class QPlainTextEdit;
 
 namespace openstudio {
 
@@ -67,6 +68,8 @@ class ScheduleFileInspectorView : public ModelObjectInspectorView
 
   void refresh();
 
+  void refreshContent();
+
   boost::optional<model::ScheduleFile> m_sch;
 
   OSLineEdit2* m_nameEdit = nullptr;
@@ -79,6 +82,9 @@ class ScheduleFileInspectorView : public ModelObjectInspectorView
   OSComboBox2* m_minutesperItem = nullptr;
   OSSwitch2* m_adjustScheduleforDaylightSavings = nullptr;
   OSSwitch2* m_translateFileWithRelativePath = nullptr;
+
+  QPlainTextEdit* m_firstLines = nullptr;
+  QStringList m_lines;
 };
 
 }  // namespace openstudio

--- a/src/openstudio_lib/ScheduleFileInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.hpp
@@ -27,110 +27,60 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#ifndef OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
-#define OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#ifndef OPENSTUDIO_SCHEDULEFILEINSPECTORVIEW_HPP
+#define OPENSTUDIO_SCHEDULEFILEINSPECTORVIEW_HPP
 
-#include "MainTabController.hpp"
+#include "ModelObjectInspectorView.hpp"
+#include <openstudio/model/ScheduleFile.hpp>
 
-#include <openstudio/model/Model.hpp>
-#include <openstudio/model/ScheduleRuleset.hpp>
-#include <openstudio/model/ScheduleRuleset_Impl.hpp>
-
-#include <openstudio/utilities/core/UUID.hpp>
-
-#include <boost/smart_ptr.hpp>
-
-#include <QObject>
+class QLineEdit;
 
 namespace openstudio {
 
-class OSItemId;
+class OSLineEdit2;
+class OSIntegerEdit2;
+class OSComboBox2;
+class OSSwitch2;
 
-namespace model {
-
-class ScheduleCompact;
-
-}
-
-class DayScheduleScene;
-
-class MainTabView;
-
-class ScheduleDialog;
-
-class ScheduleSetsController;
-
-class SchedulesView;
-
-class SchedulesTabController : public MainTabController
+class ScheduleFileInspectorView : public ModelObjectInspectorView
 {
   Q_OBJECT
 
  public:
-  SchedulesTabController(bool isIP, const model::Model& model);
+  ScheduleFileInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
 
-  virtual ~SchedulesTabController();
+  virtual ~ScheduleFileInspectorView() = default;
 
-  enum TabID
-  {
-    //YEAR_SETTINGS,
-    SCHEDULE_SETS,
-    SCHEDULES,
-    SCHEDULESOTHER
-  };
+ protected:
+  virtual void onClearSelection() override;
 
-  static double defaultStartingValue(const model::ScheduleDay& scheduleDay);
+  virtual void onSelectModelObject(const openstudio::model::ModelObject& modelObject) override;
+
+  virtual void onUpdate() override;
 
  private:
-  void showScheduleDialog();
+  void createLayout();
 
-  ScheduleDialog* m_scheduleDialog = nullptr;
+  void attach(openstudio::model::ScheduleFile& sch);
 
-  model::Model m_model;
+  void detach();
 
-  bool m_isIP;
+  void refresh();
 
-  QWidget* m_currentView = nullptr;
+  boost::optional<model::ScheduleFile> m_sch;
 
-  QObject* m_currentController = nullptr;
-
-  int m_currentIndex = -1;
-
- public slots:
-
-  virtual void setSubTab(int index) override;
-
-  void toggleUnits(bool displayIP);
-
- private slots:
-
-  void addScheduleRuleset();
-
-  void copySelectedSchedule();
-
-  void removeSelectedSchedule();
-
-  void purgeUnusedScheduleRulesets();
-
-  void addRule(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addSummerProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addWinterProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addHolidayProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void removeScheduleRule(model::ScheduleRule& scheduleRule);
-
-  void onDayScheduleSceneChanged(DayScheduleScene* scene, double lowerLimitValue, double upperLimitValue);
-
-  void onStartDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onEndDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onItemDropped(const OSItemId& itemId);
+  OSLineEdit2* m_nameEdit = nullptr;
+  QLineEdit* m_filePath = nullptr;
+  OSIntegerEdit2* m_columnNumber = nullptr;
+  OSIntegerEdit2* m_rowstoSkipatTop = nullptr;
+  OSIntegerEdit2* m_numberofHoursofData = nullptr;
+  OSComboBox2* m_columnSeparator = nullptr;
+  OSSwitch2* m_interpolatetoTimestep = nullptr;
+  OSComboBox2* m_minutesperItem = nullptr;
+  OSSwitch2* m_adjustScheduleforDaylightSavings = nullptr;
+  OSSwitch2* m_translateFileWithRelativePath = nullptr;
 };
 
 }  // namespace openstudio
 
-#endif  // OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#endif  // OPENSTUDIO_SCHEDULEFILEINSPECTORVIEW_HPP

--- a/src/openstudio_lib/ScheduleFileInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.hpp
@@ -71,6 +71,8 @@ class ScheduleFileInspectorView : public ModelObjectInspectorView
 
   void refreshContent();
 
+  void refreshError();
+
   boost::optional<model::ScheduleFile> m_sch;
 
   OSLineEdit2* m_nameEdit = nullptr;
@@ -85,6 +87,7 @@ class ScheduleFileInspectorView : public ModelObjectInspectorView
   OSSwitch2* m_translateFileWithRelativePath = nullptr;
 
   QLineEdit* m_numLines = nullptr;
+  QLabel* m_error = nullptr;
   bool m_displayAllContent = false;
   QPushButton* m_displayAllContentSwitch = nullptr;
   QPlainTextEdit* m_contentLines = nullptr;

--- a/src/openstudio_lib/ScheduleFileInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.hpp
@@ -35,6 +35,7 @@
 
 class QLineEdit;
 class QPlainTextEdit;
+class QPushButton;
 
 namespace openstudio {
 
@@ -84,6 +85,8 @@ class ScheduleFileInspectorView : public ModelObjectInspectorView
   OSSwitch2* m_translateFileWithRelativePath = nullptr;
 
   QLineEdit* m_numLines = nullptr;
+  bool m_displayAllContent = false;
+  QPushButton* m_displayAllContentSwitch = nullptr;
   QPlainTextEdit* m_contentLines = nullptr;
   QStringList m_lines;
 };

--- a/src/openstudio_lib/ScheduleFileInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.hpp
@@ -83,7 +83,8 @@ class ScheduleFileInspectorView : public ModelObjectInspectorView
   OSSwitch2* m_adjustScheduleforDaylightSavings = nullptr;
   OSSwitch2* m_translateFileWithRelativePath = nullptr;
 
-  QPlainTextEdit* m_firstLines = nullptr;
+  QLineEdit* m_numLines = nullptr;
+  QPlainTextEdit* m_contentLines = nullptr;
   QStringList m_lines;
 };
 

--- a/src/openstudio_lib/ScheduleFileInspectorView.hpp
+++ b/src/openstudio_lib/ScheduleFileInspectorView.hpp
@@ -49,7 +49,7 @@ class ScheduleFileInspectorView : public ModelObjectInspectorView
   Q_OBJECT
 
  public:
-  ScheduleFileInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
+  explicit ScheduleFileInspectorView(const openstudio::model::Model& model, QWidget* parent = nullptr);
 
   virtual ~ScheduleFileInspectorView() = default;
 

--- a/src/openstudio_lib/ScheduleOthersController.cpp
+++ b/src/openstudio_lib/ScheduleOthersController.cpp
@@ -69,8 +69,8 @@ void ScheduleOthersController::onAddObject(const openstudio::IddObjectType& iddO
         if (e_) {
           model::ScheduleFile(*e_, 1, 1);
         }
-        break;
       }
+      break;
     }
     default:
       LOG_FREE_AND_THROW("ScheduleOthersController", "Unknown IddObjectType '" << iddObjectType.valueName() << "'");

--- a/src/openstudio_lib/ScheduleOthersController.cpp
+++ b/src/openstudio_lib/ScheduleOthersController.cpp
@@ -59,7 +59,6 @@ void ScheduleOthersController::onAddObject(const openstudio::IddObjectType& iddO
       message.setText("Creation of Schedule:Compact is not supported, you should use a ScheduleRuleset instead");
       message.exec();
       return;
-      break;
     }
     case IddObjectType::OS_Schedule_File: {
       QString selfilter = tr("CSV Files(*.csv)");

--- a/src/openstudio_lib/ScheduleOthersController.cpp
+++ b/src/openstudio_lib/ScheduleOthersController.cpp
@@ -32,12 +32,17 @@
 
 #include <openstudio/model/ScheduleConstant.hpp>
 #include <openstudio/model/ScheduleConstant_Impl.hpp>
+#include <openstudio/model/ExternalFile.hpp>
+#include <openstudio/model/ExternalFile_Impl.hpp>
+#include <openstudio/model/ScheduleFile.hpp>
 
 #include <openstudio/utilities/core/Logger.hpp>
 
 #include <openstudio/utilities/idd/IddEnums.hxx>
 
 #include <QMessageBox>
+#include <QFileDialog>
+#include <QDir>
 
 namespace openstudio {
 
@@ -55,6 +60,18 @@ void ScheduleOthersController::onAddObject(const openstudio::IddObjectType& iddO
       message.exec();
       return;
       break;
+    }
+    case IddObjectType::OS_Schedule_File: {
+      QString selfilter = tr("CSV Files(*.csv)");
+      QString fileName = QFileDialog::getOpenFileName(this->subTabView(), tr("Select External File"), QDir::homePath(),
+                                                      tr("All files (*.*);;CSV Files(*.csv);;TSV Files(*.tsv)"), &selfilter);
+      if (!fileName.isNull()) {
+        boost::optional<model::ExternalFile> e_ = model::ExternalFile::getExternalFile(this->model(), fileName.toStdString());
+        if (e_) {
+          model::ScheduleFile(*e_, 1, 1);
+        }
+        break;
+      }
     }
     default:
       LOG_FREE_AND_THROW("ScheduleOthersController", "Unknown IddObjectType '" << iddObjectType.valueName() << "'");

--- a/src/openstudio_lib/ScheduleOthersController.hpp
+++ b/src/openstudio_lib/ScheduleOthersController.hpp
@@ -27,110 +27,38 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#ifndef OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
-#define OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#ifndef OPENSTUDIO_SCHEDULEOTHERSCONTROLLER_HPP
+#define OPENSTUDIO_SCHEDULEOTHERSCONTROLLER_HPP
 
-#include "MainTabController.hpp"
-
-#include <openstudio/model/Model.hpp>
-#include <openstudio/model/ScheduleRuleset.hpp>
-#include <openstudio/model/ScheduleRuleset_Impl.hpp>
-
-#include <openstudio/utilities/core/UUID.hpp>
-
-#include <boost/smart_ptr.hpp>
-
-#include <QObject>
+#include "ModelSubTabController.hpp"
 
 namespace openstudio {
 
-class OSItemId;
-
-namespace model {
-
-class ScheduleCompact;
-
-}
-
-class DayScheduleScene;
-
-class MainTabView;
-
-class ScheduleDialog;
-
-class ScheduleSetsController;
-
-class SchedulesView;
-
-class SchedulesTabController : public MainTabController
+class ScheduleOthersController : public ModelSubTabController
 {
   Q_OBJECT
 
  public:
-  SchedulesTabController(bool isIP, const model::Model& model);
+  explicit ScheduleOthersController(const model::Model& model);
 
-  virtual ~SchedulesTabController();
+  virtual ~ScheduleOthersController() = default;
 
-  enum TabID
-  {
-    //YEAR_SETTINGS,
-    SCHEDULE_SETS,
-    SCHEDULES,
-    SCHEDULESOTHER
-  };
+ protected:
+  virtual void onAddObject(const openstudio::IddObjectType& iddObjectType) override;
 
-  static double defaultStartingValue(const model::ScheduleDay& scheduleDay);
+  virtual void onCopyObject(const openstudio::model::ModelObject& modelObject) override;
 
- private:
-  void showScheduleDialog();
+  virtual void onRemoveObject(openstudio::model::ModelObject modelObject) override;
 
-  ScheduleDialog* m_scheduleDialog = nullptr;
+  virtual void onReplaceObject(openstudio::model::ModelObject modelObject, const OSItemId& replacementItemId) override;
 
-  model::Model m_model;
+  virtual void onPurgeObjects(const openstudio::IddObjectType& iddObjectType) override;
 
-  bool m_isIP;
+  virtual void onDrop(const OSItemId& itemId) override;
 
-  QWidget* m_currentView = nullptr;
-
-  QObject* m_currentController = nullptr;
-
-  int m_currentIndex = -1;
-
- public slots:
-
-  virtual void setSubTab(int index) override;
-
-  void toggleUnits(bool displayIP);
-
- private slots:
-
-  void addScheduleRuleset();
-
-  void copySelectedSchedule();
-
-  void removeSelectedSchedule();
-
-  void purgeUnusedScheduleRulesets();
-
-  void addRule(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addSummerProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addWinterProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addHolidayProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void removeScheduleRule(model::ScheduleRule& scheduleRule);
-
-  void onDayScheduleSceneChanged(DayScheduleScene* scene, double lowerLimitValue, double upperLimitValue);
-
-  void onStartDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onEndDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onItemDropped(const OSItemId& itemId);
+  virtual void onInspectItem(OSItem* item) override;
 };
 
 }  // namespace openstudio
 
-#endif  // OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#endif  // OPENSTUDIO_SCHEDULEOTHERSCONTROLLER_HPP

--- a/src/openstudio_lib/ScheduleOthersView.cpp
+++ b/src/openstudio_lib/ScheduleOthersView.cpp
@@ -1,0 +1,126 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2020-2023, OpenStudio Coalition and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#include "ScheduleOthersView.hpp"
+#include "ModelObjectTypeListView.hpp"
+
+#include "ScheduleConstantInspectorView.hpp"
+#include "ScheduleCompactInspectorView.hpp"
+#include "ScheduleFileInspectorView.hpp"
+
+#include <openstudio/model/Model_Impl.hpp>
+
+#include <openstudio/utilities/core/Assert.hpp>
+#include <openstudio/utilities/idd/IddEnums.hxx>
+
+#include <QStackedWidget>
+
+namespace openstudio {
+
+ScheduleOthersView::ScheduleOthersView(const openstudio::model::Model& model, QWidget* parent)
+  : ModelSubTabView(
+    new ModelObjectTypeListView(ScheduleOthersView::modelObjectTypesAndNames(), model, true, OSItemType::CollapsibleListHeader, false, parent),
+    new ScheduleOthersInspectorView(model, parent), false, parent) {}
+
+std::vector<std::pair<IddObjectType, std::string>> ScheduleOthersView::modelObjectTypesAndNames() {
+  return {{
+    {IddObjectType::OS_Schedule_Constant, "Schedule Constant"},
+    {IddObjectType::OS_Schedule_Compact, "Schedule Compact"},
+    {IddObjectType::OS_Schedule_File, "Schedule File"},
+  }};
+}
+
+ScheduleOthersInspectorView::ScheduleOthersInspectorView(const model::Model& model, QWidget* parent)
+  : ModelObjectInspectorView(model, false, parent) {}
+
+void ScheduleOthersInspectorView::onClearSelection() {
+  QWidget* widget = this->stackedWidget()->currentWidget();
+  auto* modelObjectInspectorView = qobject_cast<ModelObjectInspectorView*>(widget);
+  if (modelObjectInspectorView) {
+    modelObjectInspectorView->clearSelection();
+  }
+
+  this->stackedWidget()->setCurrentIndex(0);
+}
+
+void ScheduleOthersInspectorView::onUpdate() {}
+
+void ScheduleOthersInspectorView::onSelectModelObject(const openstudio::model::ModelObject& modelObject) {
+  switch (modelObject.iddObjectType().value()) {
+    case IddObjectType::OS_Schedule_Constant:
+      this->showScheduleConstantView(modelObject);
+      break;
+    case IddObjectType::OS_Schedule_Compact:
+      this->showScheduleCompactView(modelObject);
+      break;
+    case IddObjectType::OS_Schedule_File:
+      this->showScheduleFileView(modelObject);
+      break;
+    default:
+      showDefaultView();
+  }
+}
+
+void ScheduleOthersInspectorView::showScheduleConstantView(const openstudio::model::ModelObject& modelObject) {
+  auto* view = new ScheduleConstantInspectorView(m_model);
+  view->selectModelObject(modelObject);
+  this->showInspector(view);
+}
+
+void ScheduleOthersInspectorView::showScheduleCompactView(const openstudio::model::ModelObject& modelObject) {
+  auto* view = new ScheduleCompactInspectorView(m_model);
+  view->selectModelObject(modelObject);
+  this->showInspector(view);
+}
+
+void ScheduleOthersInspectorView::showScheduleFileView(const openstudio::model::ModelObject& modelObject) {
+  auto* view = new ScheduleFileInspectorView(m_model);
+  view->selectModelObject(modelObject);
+  this->showInspector(view);
+}
+
+void ScheduleOthersInspectorView::showInspector(QWidget* widget) {
+  if (QWidget* _widget = this->stackedWidget()->currentWidget()) {
+    this->stackedWidget()->removeWidget(_widget);
+
+    delete _widget;
+  }
+
+  this->stackedWidget()->addWidget(widget);
+}
+
+void ScheduleOthersInspectorView::showDefaultView() {
+  if (QWidget* widget = this->stackedWidget()->currentWidget()) {
+    this->stackedWidget()->removeWidget(widget);
+
+    delete widget;
+  }
+}
+
+}  // namespace openstudio

--- a/src/openstudio_lib/ScheduleOthersView.hpp
+++ b/src/openstudio_lib/ScheduleOthersView.hpp
@@ -27,110 +27,59 @@
 *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***********************************************************************************************************************/
 
-#ifndef OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
-#define OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#ifndef OPENSTUDIO_SCHEDULEOTHERSVIEW_HPP
+#define OPENSTUDIO_SCHEDULEOTHERSVIEW_HPP
 
-#include "MainTabController.hpp"
+#include "ModelSubTabView.hpp"
+#include "ModelObjectInspectorView.hpp"
 
 #include <openstudio/model/Model.hpp>
-#include <openstudio/model/ScheduleRuleset.hpp>
-#include <openstudio/model/ScheduleRuleset_Impl.hpp>
 
-#include <openstudio/utilities/core/UUID.hpp>
-
-#include <boost/smart_ptr.hpp>
-
-#include <QObject>
+class QStackedWidget;
 
 namespace openstudio {
 
-class OSItemId;
-
-namespace model {
-
-class ScheduleCompact;
-
-}
-
-class DayScheduleScene;
-
-class MainTabView;
-
-class ScheduleDialog;
-
-class ScheduleSetsController;
-
-class SchedulesView;
-
-class SchedulesTabController : public MainTabController
+class ScheduleOthersView : public ModelSubTabView
 {
   Q_OBJECT
 
  public:
-  SchedulesTabController(bool isIP, const model::Model& model);
+  explicit ScheduleOthersView(const openstudio::model::Model& model, QWidget* parent = nullptr);
 
-  virtual ~SchedulesTabController();
-
-  enum TabID
-  {
-    //YEAR_SETTINGS,
-    SCHEDULE_SETS,
-    SCHEDULES,
-    SCHEDULESOTHER
-  };
-
-  static double defaultStartingValue(const model::ScheduleDay& scheduleDay);
+  virtual ~ScheduleOthersView() = default;
 
  private:
-  void showScheduleDialog();
+  static std::vector<std::pair<IddObjectType, std::string>> modelObjectTypesAndNames();
+};
 
-  ScheduleDialog* m_scheduleDialog = nullptr;
+class ScheduleOthersInspectorView : public ModelObjectInspectorView
+{
+  Q_OBJECT
 
-  model::Model m_model;
+ public:
+  explicit ScheduleOthersInspectorView(const model::Model& model, QWidget* parent = nullptr);
 
-  bool m_isIP;
+  virtual ~ScheduleOthersInspectorView() = default;
 
-  QWidget* m_currentView = nullptr;
+ protected:
+  virtual void onClearSelection() override;
 
-  QObject* m_currentController = nullptr;
+  virtual void onSelectModelObject(const openstudio::model::ModelObject& modelObject) override;
 
-  int m_currentIndex = -1;
+  virtual void onUpdate() override;
 
- public slots:
+ private:
+  void showScheduleConstantView(const openstudio::model::ModelObject& modelObject);
+  void showScheduleCompactView(const openstudio::model::ModelObject& modelObject);
+  void showScheduleFileView(const openstudio::model::ModelObject& modelObject);
 
-  virtual void setSubTab(int index) override;
+  void showInspector(QWidget* widget);
 
-  void toggleUnits(bool displayIP);
+  void showDefaultView();
 
- private slots:
-
-  void addScheduleRuleset();
-
-  void copySelectedSchedule();
-
-  void removeSelectedSchedule();
-
-  void purgeUnusedScheduleRulesets();
-
-  void addRule(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addSummerProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addWinterProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void addHolidayProfile(model::ScheduleRuleset& scheduleRuleset, UUID scheduleDayHandle);
-
-  void removeScheduleRule(model::ScheduleRule& scheduleRule);
-
-  void onDayScheduleSceneChanged(DayScheduleScene* scene, double lowerLimitValue, double upperLimitValue);
-
-  void onStartDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onEndDateTimeChanged(model::ScheduleRule& scheduleRule, const QDateTime& newDate);
-
-  void onItemDropped(const OSItemId& itemId);
+  std::map<openstudio::IddObjectType, int> m_inspectorIndexMap;
 };
 
 }  // namespace openstudio
 
-#endif  // OPENSTUDIO_SCHEDULESTABCONTROLLER_HPP
+#endif  // OPENSTUDIO_SCHEDULEOTHERSVIEW_HPP

--- a/src/openstudio_lib/SchedulesView.cpp
+++ b/src/openstudio_lib/SchedulesView.cpp
@@ -35,6 +35,7 @@
 #include "OSItem.hpp"
 #include "OSItemSelectorButtons.hpp"
 #include "../shared_gui_components/OSLineEdit.hpp"
+#include "../shared_gui_components/ColorPalettes.hpp"
 
 #include <openstudio/model/Model.hpp>
 #include <openstudio/model/Model_Impl.hpp>
@@ -58,6 +59,7 @@
 
 #include <QButtonGroup>
 #include <QCalendarWidget>
+#include <QColor>
 #include <QDateTime>
 #include <QDateTimeEdit>
 #include <QDoubleSpinBox>
@@ -87,28 +89,6 @@ namespace openstudio {
 /******************************************************************************/
 // SchedulesView
 /******************************************************************************/
-
-const std::vector<QColor> SchedulesView::colors = SchedulesView::initializeColors();
-
-std::vector<QColor> SchedulesView::initializeColors() {
-  std::vector<QColor> _colors(13);
-
-  _colors[0] = QColor(170, 68, 153);
-  _colors[1] = QColor(51, 34, 136);
-  _colors[2] = QColor(17, 119, 51);
-  _colors[3] = QColor(153, 153, 51);
-  _colors[4] = QColor(221, 204, 119);
-  _colors[5] = QColor(204, 102, 119);
-  _colors[6] = QColor(136, 34, 85);
-  _colors[7] = QColor(68, 170, 153);
-  _colors[8] = QColor(102, 153, 204);
-  _colors[9] = QColor(102, 17, 0);
-  _colors[10] = QColor(170, 68, 102);
-  _colors[11] = QColor(80, 80, 80);
-  _colors[12] = QColor(136, 204, 238);
-
-  return _colors;
-}
 
 SchedulesView::SchedulesView(bool isIP, const model::Model& model)
   : m_model(model), m_leftVLayout(new QVBoxLayout()), m_contentLayout(new QHBoxLayout()), m_isIP(isIP) {
@@ -1056,7 +1036,7 @@ void ScheduleTabRule::paintEvent(QPaintEvent* /*event*/) {
     p.drawRect(0, 0, size().width() - 1, size().height() - 1);
   }
 
-  p.setBrush(QBrush(m_scheduleTab->schedulesView()->colors[i]));
+  p.setBrush(QBrush(ColorPalettes::schedule_rules_colors[i]));
 
   p.setPen(Qt::SolidLine);
 
@@ -1167,7 +1147,7 @@ void ScheduleTabDefault::paintEvent(QPaintEvent* /*event*/) {
 
   // DLM: don't draw color squares for special days (winter/summer design days and Holiday)
   if (m_type == DEFAULT) {
-    p.setBrush(QBrush(m_scheduleTab->schedulesView()->colors[12]));
+    p.setBrush(QBrush(ColorPalettes::schedule_rules_colors[12]));
     p.drawRect(0, 0, 5, size().height() - 1);
   }
 
@@ -1585,7 +1565,7 @@ ScheduleRuleView::ScheduleRuleView(bool isIP, const model::ScheduleRule& schedul
   if (colorIndex > 12) {
     colorIndex = 12;
   }
-  QColor color = m_schedulesView->colors[colorIndex];
+  QColor color = ColorPalettes::schedule_rules_colors[colorIndex];
   colorStyle.append(color.name());
   colorStyle.append("; }");
   colorWidget->setStyleSheet(colorStyle);
@@ -2103,14 +2083,14 @@ void ScheduleCalendarWidget::paintCell(QPainter* painter, const QRect& rect, QDa
 
     int ruleIndex = m_monthView->yearOverview()->activeRuleIndices()[dayOfYear - 1];
 
-    QColor ruleColor = SchedulesView::colors[12];
+    QColor ruleColor = ColorPalettes::schedule_rules_colors[12];
 
     if (ruleIndex > 12) {
       ruleIndex = 12;
     }
 
     if (ruleIndex > -1) {
-      ruleColor = SchedulesView::colors[ruleIndex];
+      ruleColor = ColorPalettes::schedule_rules_colors[ruleIndex];
     }
 
     QString dateString = QString::number(date.day());

--- a/src/openstudio_lib/SchedulesView.hpp
+++ b/src/openstudio_lib/SchedulesView.hpp
@@ -45,8 +45,6 @@
 #include <boost/optional.hpp>
 #include <boost/smart_ptr.hpp>
 
-#include <map>
-
 #include <QCalendarWidget>
 #include <QColor>
 #include <QComboBox>
@@ -132,10 +130,6 @@ class SchedulesView
   Q_OBJECT
 
  public:
-  static const std::vector<QColor> colors;
-
-  static std::vector<QColor> initializeColors();
-
   SchedulesView(bool isIP, const model::Model& model);
 
   virtual ~SchedulesView() = default;

--- a/src/shared_gui_components/ColorPalettes.hpp
+++ b/src/shared_gui_components/ColorPalettes.hpp
@@ -1,0 +1,63 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) 2020-2023, OpenStudio Coalition and other contributors. All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+*  following conditions are met:
+*
+*  (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+*  disclaimer.
+*
+*  (2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+*  disclaimer in the documentation and/or other materials provided with the distribution.
+*
+*  (3) Neither the name of the copyright holder nor the names of any contributors may be used to endorse or promote products
+*  derived from this software without specific prior written permission from the respective party.
+*
+*  (4) Other than as required in clauses (1) and (2), distributions in any form of modifications or other derivative works
+*  may not use the "OpenStudio" trademark, "OS", "os", or any other confusingly similar designation without specific prior
+*  written permission from Alliance for Sustainable Energy, LLC.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND ANY CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+*  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+*  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER(S), ANY CONTRIBUTORS, THE UNITED STATES GOVERNMENT, OR THE UNITED
+*  STATES DEPARTMENT OF ENERGY, NOR ANY OF THEIR EMPLOYEES, BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+*  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+*  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+*  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+***********************************************************************************************************************/
+
+#ifndef SHAREDGUICOMPONENTS_COLORPALETTES_HPP
+#define SHAREDGUICOMPONENTS_COLORPALETTES_HPP
+
+#include <array>
+
+#include <QColor>
+
+namespace openstudio {
+
+namespace ColorPalettes {
+
+static constexpr std::array<QColor, 13> schedule_rules_colors{{
+  // {r, g, b},     // **approximative** color name (found closest match from SVG color keyword name from World Wide Web Consortium)
+  {170, 68, 153},   // darkorchid
+  {51, 34, 136},    // darkslateblue
+  {17, 119, 51},    // forestgreen
+  {153, 153, 51},   // olivedrab
+  {221, 204, 119},  // burlywood
+  {204, 102, 119},  // indianred
+  {136, 34, 85},    // brown
+  {68, 170, 153},   // cadetblue
+  {102, 153, 204},  // cornflowerblue
+  {102, 17, 0},     // maroon
+  {170, 68, 102},   // indianred
+  {80, 80, 80},     // darkslategray
+  {136, 204, 238},  // skyblue
+
+}};
+
+}  // namespace ColorPalettes
+
+}  // namespace openstudio
+
+#endif  // SHAREDGUICOMPONENTS_COLORPALETTES_HPP

--- a/src/shared_gui_components/OSGridController.cpp
+++ b/src/shared_gui_components/OSGridController.cpp
@@ -43,7 +43,6 @@
 #include "../openstudio_lib/OSDropZone.hpp"
 #include "../openstudio_lib/OSItemSelector.hpp"
 #include "../openstudio_lib/RenderingColorWidget.hpp"
-#include "../openstudio_lib/SchedulesView.hpp"
 
 #include <openstudio/model/Model_Impl.hpp>
 #include <openstudio/model/ModelObject_Impl.hpp>
@@ -75,8 +74,6 @@
 #include <iterator>
 
 namespace openstudio {
-
-const std::vector<QColor> OSGridController::m_colors = SchedulesView::initializeColors();
 
 OSGridController::OSGridController()
   : m_hasHorizontalHeader(true),

--- a/src/shared_gui_components/OSGridController.hpp
+++ b/src/shared_gui_components/OSGridController.hpp
@@ -530,8 +530,6 @@ class OSGridController : public QObject
 
   std::vector<QString> m_customFields;
 
-  static const std::vector<QColor> m_colors;
-
   model::Model m_model;
 
   bool m_isIP;


### PR DESCRIPTION
# ScheduleConstant

Easy peasy

![image](https://github.com/user-attachments/assets/55e24a91-613e-4ac7-a252-0420c198b7ff)


# ScheduleFile

Creating is possible, will ask for the external file on disk.

Added a lot of usability there, will display the content of the external file and show what data you're selecting, warn you if not matching, etc

![image](https://github.com/user-attachments/assets/913ea202-80ed-471c-b888-8d9cb9792980)

# ScheduleCompact

Displaying the object as is. Not possible to create, will tell you to use a ScheduleRuleset instead

![image](https://github.com/user-attachments/assets/a862da38-52b4-4547-aa27-ea469d8c8f6a)


# Demo

![162](https://github.com/user-attachments/assets/18070d3e-0153-4edb-be22-220596a2dce3)
