### PR TITLE
Fix a race condition during CPack packaging when creating symlink on Apple

### DIFF
--- a/src/openstudio_app/CMakeLists.txt
+++ b/src/openstudio_app/CMakeLists.txt
@@ -472,6 +472,13 @@ if( APPLE )
           "${CMAKE_INSTALL_PREFIX}/OpenStudioApp.app/Contents/Frameworks/$<TARGET_FILE_NAME:openstudio::openstudiolib>"
 
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_INSTALL_PREFIX}/bin"
+
+        COMMAND_ECHO STDOUT
+        COMMAND_ERROR_IS_FATAL ANY
+      )
+
+      # We break it into two `execute_process`es so that there is no race condition between the make_directory above and the create_symlink below
+      execute_process(
         COMMAND "${CMAKE_COMMAND}" -E create_symlink
           "../OpenStudioApp.app/Contents/MacOS/$<TARGET_FILE_NAME:openstudio::openstudio>"
           "${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:openstudio::openstudio>"


### PR DESCRIPTION
cf https://github.com/openstudiocoalition/OpenStudioApplication/pull/727#issuecomment-2312165298

I can reproduce the error even locally on Ubuntu:

```cmake
option(USE_TWO_EXECUTE "Use two execute_process instead of a single one" OFF)

if(USE_TWO_EXECUTE)
  execute_process(
    COMMAND echo "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}"

    COMMAND "${CMAKE_COMMAND}" -E make_directory "bin"

    COMMAND_ECHO STDOUT
    COMMAND_ERROR_IS_FATAL ANY
  )

  execute_process(
    COMMAND "${CMAKE_COMMAND}" -E create_symlink
      "../OpenStudioApp.app/Contents/MacOS/openstudio"
      "bin/openstudio"

    COMMAND_ECHO STDOUT
    COMMAND_ERROR_IS_FATAL ANY
  )
else()
  execute_process(
    COMMAND echo "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}"

    COMMAND "${CMAKE_COMMAND}" -E make_directory "bin"

    COMMAND "${CMAKE_COMMAND}" -E create_symlink
      "../OpenStudioApp.app/Contents/MacOS/openstudio"
      "bin/openstudio"

    COMMAND_ECHO STDOUT
    COMMAND_ERROR_IS_FATAL ANY
  )
endif()
```

```shell
for i in {0..20}; do rm -Rf bin && cmake -DUSE_TWO_EXECUTE:BOOL=OFF . || (echo "FAILED" && break); done
```

![image](https://github.com/user-attachments/assets/422067e0-c06f-48f0-af9f-2756669e4c35)

```shell
for i in {0..20}; do rm -Rf bin && cmake -DUSE_TWO_EXECUTE:BOOL=ON . || (echo "FAILED" && break); done
```