### PR TITLE
Fix #671 - Mark Python Measures as in Error if use classic CLI to run the simulation

### DIFF
--- a/src/shared_gui_components/LocalLibraryController.cpp
+++ b/src/shared_gui_components/LocalLibraryController.cpp
@@ -521,7 +521,11 @@ QWidget* LibraryItemDelegate::view(QSharedPointer<OSListItem> dataSource) {
     // Name
 
     widget->label->setText(libraryItem->displayName());
-    if (libraryItem->hasError()) {
+    const bool useClassicCLI = OSAppBase::instance()->currentDocument()->mainWindow()->useClassicCLI();
+    if (useClassicCLI && (measureLanguage == MeasureLanguage::Python)) {
+      widget->setToolTip("Python Measures are not supported in the Classic CLI.\nYou can change CLI version using 'Preferences->Use Classic CLI'.");
+      widget->errorLabel->setVisible(true);
+    } else if (libraryItem->hasError()) {
       widget->setToolTip(libraryItem->error());
       widget->errorLabel->setVisible(true);
     } else {


### PR DESCRIPTION
* Fix #671 
 
This will require you to change tab and come back after an update to your preferences, but that's ok because this is a temporary thing anyways, as the OpenStudio SDK has deprecated the classic CLI and will remove it soonish.

![671](https://github.com/user-attachments/assets/cd92c8c4-a1fa-4472-b4d9-61900c443f8b)
