### PR TITLE
Fix #758 - Properly encode path to QUrl when trying to display results

### DIFF
--- a/src/model_editor/test/Utilities_GTest.cpp
+++ b/src/model_editor/test/Utilities_GTest.cpp
@@ -123,7 +123,7 @@ TEST_F(ModelEditorFixture, MorePath_Conversions) {
     QString expectedUrl;
   };
 
-  std::vector<PathTestCase> testCases = { 
+  std::vector<PathTestCase> testCases = {
     {"C:\\Users\\Test\\eplustbl.html", "C:/Users/Test/eplustbl.html", "file:///C:/Users/Test/eplustbl.html"},
     {"C:/Users/Test/eplustbl.html", "C:/Users/Test/eplustbl.html", "file:///C:/Users/Test/eplustbl.html"},
     {"C:\\Users/Test/eplustbl.html", "C:/Users/Test/eplustbl.html", "file:///C:/Users/Test/eplustbl.html"},
@@ -141,8 +141,8 @@ TEST_F(ModelEditorFixture, MorePath_Conversions) {
     EXPECT_EQ(url.toString(QUrl::FullyEncoded), testCase.expectedUrl);
 
     std::cout << "Input: " << testCase.inputPath << ", "
-      << "OS Path: " << osPath << ", "
-      << "QPath: " << qPath.toStdString() << ", "
-      << "Url: " << url.toString().toStdString() << std::endl;
+              << "OS Path: " << osPath << ", "
+              << "QPath: " << qPath.toStdString() << ", "
+              << "Url: " << url.toString().toStdString() << std::endl;
   }
 }

--- a/src/model_editor/test/Utilities_GTest.cpp
+++ b/src/model_editor/test/Utilities_GTest.cpp
@@ -11,6 +11,7 @@
 #include "../Utilities.hpp"
 
 #include <clocale>
+#include <QUrl>
 
 using openstudio::toPath;
 using openstudio::toQString;
@@ -112,4 +113,36 @@ TEST_F(ModelEditorFixture, Path_Conversions) {
   EXPECT_EQ(t, toString(toQString(toString(p))));
   EXPECT_EQ(t, std::string(toQString(toString(p)).toUtf8()));
   EXPECT_EQ(t, toString(toPath(toQString(toString(p)))));
+}
+
+TEST_F(ModelEditorFixture, MorePath_Conversions) {
+  struct PathTestCase
+  {
+    std::string inputPath;
+    QString expectedPath;
+    QString expectedUrl;
+  };
+
+  std::vector<PathTestCase> testCases = { 
+    {"C:\\Users\\Test\\eplustbl.html", "C:/Users/Test/eplustbl.html", "file:///C:/Users/Test/eplustbl.html"},
+    {"C:/Users/Test/eplustbl.html", "C:/Users/Test/eplustbl.html", "file:///C:/Users/Test/eplustbl.html"},
+    {"C:\\Users/Test/eplustbl.html", "C:/Users/Test/eplustbl.html", "file:///C:/Users/Test/eplustbl.html"},
+    {"C:\\Users\\Test# ^\\eplustbl.html", "C:/Users/Test# ^/eplustbl.html", "file:///C:/Users/Test%23%20%5E/eplustbl.html"},
+    {"/home/Test/eplustbl.html", "/home/Test/eplustbl.html", "file:///home/Test/eplustbl.html"},
+    {"/home/Test# ^/eplustbl.html", "/home/Test# ^/eplustbl.html", "file:///home/Test%23%20%5E/eplustbl.html"},
+  };
+
+  // double check the conversions in openstudio_lib/ResultsTabView.cpp
+  for (const auto& testCase : testCases) {
+    openstudio::path osPath = toPath(testCase.inputPath);
+    QString qPath = toQString(osPath);
+    EXPECT_EQ(qPath, testCase.expectedPath);
+    QUrl url = QUrl::fromLocalFile(qPath);
+    EXPECT_EQ(url.toString(QUrl::FullyEncoded), testCase.expectedUrl);
+
+    std::cout << "Input: " << testCase.inputPath << ", "
+      << "OS Path: " << osPath << ", "
+      << "QPath: " << qPath.toStdString() << ", "
+      << "Url: " << url.toString().toStdString() << std::endl;
+  }
 }

--- a/src/openstudio_lib/ResultsTabView.cpp
+++ b/src/openstudio_lib/ResultsTabView.cpp
@@ -301,7 +301,6 @@ void ResultsView::populateComboBox(const std::vector<openstudio::path>& reports)
     QString fullPathString = toQString(report);
 
     QFile file(fullPathString);
-    fullPathString.prepend("file:///");
 
     if (openstudio::toString(report.filename()) == "eplustbl.html" || openstudio::toString(report.filename()) == "eplustbl.htm") {
 
@@ -360,7 +359,7 @@ void ResultsView::comboBoxChanged(int index) {
 
   m_progressBar->setError(false);
 
-  QUrl url(filename);
+  QUrl url = QUrl::fromLocalFile(filename);
   m_view->load(url);
 }
 


### PR DESCRIPTION
My two cents: NEVER USE special characters for files or directory names. Nor space. 

Limit all file names to numbers ([0-9]) letters ([a-zA-Z]), and "-", "_" and "." You'll live a a much happier life generally.