### PR TITLE
Fix #262 #263 - Handle Path Arguments (QFileDialog)

### DIFF
--- a/src/shared_gui_components/EditController.hpp
+++ b/src/shared_gui_components/EditController.hpp
@@ -81,6 +81,8 @@ class InputController : public QObject
 
   void setValue(bool value);
 
+  void setValue(const openstudio::path& p);
+
   void setValueForIndex(int index);
 
  private:

--- a/src/shared_gui_components/EditView.hpp
+++ b/src/shared_gui_components/EditView.hpp
@@ -6,14 +6,16 @@
 #ifndef SHAREDGUICOMPONENTS_EDITVIEW_HPP
 #define SHAREDGUICOMPONENTS_EDITVIEW_HPP
 
-#include <QWidget>
-#include <QComboBox>
 #include <QAbstractButton>
+#include <QComboBox>
 #include <QLabel>
+#include <QWidget>
 
 #include <boost/optional.hpp>
+#include <openstudio/utilities/core/Filesystem.hpp>
 
 class QLineEdit;
+class QPushButton;
 class QTextEdit;
 class QVBoxLayout;
 
@@ -27,7 +29,7 @@ class EditNullView : public QWidget
 
  public:
   explicit EditNullView(const QString& text = "Select a Measure to Edit");
-  virtual ~EditNullView() {}
+  virtual ~EditNullView() = default;
 
  protected:
   void paintEvent(QPaintEvent*) override;
@@ -39,7 +41,7 @@ class EditRubyMeasureView : public QWidget
 
  public:
   explicit EditRubyMeasureView(bool applyMeasureNow);
-  virtual ~EditRubyMeasureView() {}
+  virtual ~EditRubyMeasureView() = default;
 
   QLineEdit* nameLineEdit;
 
@@ -77,7 +79,7 @@ class DoubleInputView : public InputView
 
  public:
   DoubleInputView();
-  virtual ~DoubleInputView() {}
+  virtual ~DoubleInputView() = default;
 
   QLineEdit* lineEdit;
 
@@ -97,7 +99,7 @@ class ChoiceInputView : public InputView
 
  public:
   ChoiceInputView();
-  virtual ~ChoiceInputView() {}
+  virtual ~ChoiceInputView() = default;
 
   QComboBox* comboBox;
 
@@ -117,7 +119,7 @@ class BoolInputView : public InputView
 
  public:
   BoolInputView();
-  virtual ~BoolInputView() {}
+  virtual ~BoolInputView() = default;
 
   InputCheckBox* checkBox;
 
@@ -134,7 +136,7 @@ class IntegerInputView : public InputView
 
  public:
   IntegerInputView();
-  virtual ~IntegerInputView() {}
+  virtual ~IntegerInputView() = default;
 
   QLineEdit* lineEdit;
 
@@ -154,7 +156,7 @@ class StringInputView : public InputView
 
  public:
   StringInputView();
-  virtual ~StringInputView() {}
+  virtual ~StringInputView() = default;
 
   QLineEdit* lineEdit;
 
@@ -183,7 +185,7 @@ class InputCheckBox : public QAbstractButton
  public:
   InputCheckBox();
 
-  virtual ~InputCheckBox();
+  virtual ~InputCheckBox() = default;
 
   void setText(const QString& text);
 
@@ -194,6 +196,35 @@ class InputCheckBox : public QAbstractButton
 
  private:
   QLabel* m_label;
+};
+
+class PathInputView : public InputView
+{
+  Q_OBJECT
+
+ public:
+  PathInputView(const std::string& extension, bool isRead);
+  virtual ~PathInputView() = default;
+
+  QLineEdit* lineEdit;
+  QPushButton* selectPathButton;
+
+  void setName(const std::string& name, const boost::optional<std::string>& units, const boost::optional<std::string>& description);
+
+  void setIncomplete(bool incomplete) override;
+
+  void setDisplayValue(const QVariant& value) override;
+
+ signals:
+  void selectedPathChanged(const openstudio::path& p);
+
+ private slots:
+  void onSelectPathButtonClicked();
+
+ private:
+  QLabel* nameLabel;
+  QString m_extension;
+  bool m_isRead;
 };
 
 }  // namespace openstudio

--- a/src/shared_gui_components/MeasureManager.cpp
+++ b/src/shared_gui_components/MeasureManager.cpp
@@ -607,8 +607,10 @@ boost::optional<measure::OSArgument> MeasureManager::getArgument(const measure::
 
   } else if (type.value() == measure::OSArgumentType::Path) {
 
+    // TODO: aside from the fact that these arguments are weird / incorrectly named, neither the BCL-gem schema nor OS SDK actually handle them so
+    // they are not even inside the measure.xml
     bool isRead = argument.get("is_read", Json::Value(false)).asBool();
-    std::string extension = argument.get("extension", Json::Value("*")).asString();
+    std::string extension = argument.get("extension", Json::Value("All files (*)")).asString();
 
     result = measure::OSArgument::makePathArgument(name, isRead, extension, required, modelDependent);
 

--- a/src/shared_gui_components/WorkflowController.cpp
+++ b/src/shared_gui_components/WorkflowController.cpp
@@ -501,6 +501,8 @@ void MeasureStepItem::setArgument(const measure::OSArgument& argument) {
       m_step.setArgument(argument.name(), argument.valueAsDouble());
     } else if (argument.type() == measure::OSArgumentType::Integer) {
       m_step.setArgument(argument.name(), argument.valueAsInteger());
+    } else if (argument.type() == measure::OSArgumentType::Path) {
+      m_step.setArgument(argument.name(), openstudio::toString(argument.valueAsPath()));
     } else {
       m_step.setArgument(argument.name(), argument.valueAsString());
     }


### PR DESCRIPTION
* Fix #262 
* Fix #263

The OS SDK / BCL-gem implementation of the path arguments is incomplete and confusing, and they don't handle the makePathArgument  arguments:

*  `isRead`. what does that even mean? Is this assuming that this is for **reading** meaning it must be 1) a file (not a directory) and 2) it must exist?)
* `extension`

![path_arguments](https://github.com/user-attachments/assets/a8813cd1-b58c-45c8-8797-f5dc1e47ac94)

