### PR TITLE
Fix #815 - Add OutputControl:ResilienceSummaries to OS App

### DIFF
--- a/src/openstudio_lib/SimSettingsView.hpp
+++ b/src/openstudio_lib/SimSettingsView.hpp
@@ -71,6 +71,7 @@ class SimSettingsView
   QWidget* createOutputJSONWidget();
   QWidget* createOutputTableSummaryReportsWidget();
   QWidget* createOutputDiagnosticsWidget();
+  QWidget* createOutputControlResilienceSummariesWidget();
 
   void addField(QGridLayout* gridLayout, int row, int column, QString text, OSComboBox2*& comboBox);
 
@@ -110,6 +111,7 @@ class SimSettingsView
   void attachOutputJSON();
   void attachOutputTableSummaryReports();
   void attachOutputDiagnostics();
+  void attachOutputControlResilienceSummaries();
 
   void detachAll();
   void detachRunPeriod();
@@ -131,6 +133,7 @@ class SimSettingsView
   void detachOutputJSON();
   void detachOutputTableSummaryReports();
   void detachOutputDiagnostics();
+  void detachOutputControlResilienceSummaries();
 
   model::Model m_model;
   boost::optional<model::ShadowCalculation> m_shadowCalculation;
@@ -271,6 +274,8 @@ class SimSettingsView
   // These are extensible groups in the SDK, but we care only about common settings
   OSSwitch2* m_table_allSummary;
   OSSwitch2* m_diagnostics_displayExtraWarnings;
+
+  OSComboBox2* m_outputControlResilienceSummaries_heatIndexAlgorithm;
 
  signals:
 


### PR DESCRIPTION
* Fix  #815 

![815](https://github.com/user-attachments/assets/9986995e-7d33-497d-91ef-b13fd521271a)
