### PR TITLE
#825 - Expose Terrain, Elevation and Keep Site Location Information on the Site Tab

### DIFF
--- a/src/openstudio_lib/LocationTabView.cpp
+++ b/src/openstudio_lib/LocationTabView.cpp
@@ -281,17 +281,18 @@ LocationView::LocationView(bool isIP, const model::Model& model, const QString& 
       m_keepSiteLocationInfo->bind(*m_site, BoolGetter([this] { return m_site->keepSiteLocationInformation(); }),
                                    boost::optional<BoolSetter>([this](bool b) {
                                      bool result = m_site->setKeepSiteLocationInformation(b);
+
                                      if (result) {
 
-                                       // force a change to force the style to update
-                                       double elev = m_site->elevation();
-                                       m_site->setElevation((elev > 0) ? elev - 1 : elev + 1);
+                                       // force the style to update
+                                       m_elevation->clearCachedText();
+
                                        if (b) {
                                          // set elevation if turning on
                                          if (m_site->isElevationDefaulted()) {
                                            m_site->setElevation(m_weatherFileElevation);
                                          } else {
-                                           m_site->setElevation(elev);
+                                           m_site->setElevation(m_site->elevation());
                                          }
                                        } else {
                                          // reset elevation if turning off
@@ -499,9 +500,10 @@ LocationView::LocationView(bool isIP, const model::Model& model, const QString& 
                       boost::optional<NoFailAction>([this] {
                         // turn keep site info off
                         m_site->setKeepSiteLocationInformation(false);
-                        // force a change to force the style to update
-                        double elev = m_site->elevation();
-                        m_site->setElevation((elev > 0) ? elev - 1 : elev + 1);
+
+                        // force the style to update
+                        m_elevation->clearCachedText();
+
                         if (std::abs(m_weatherFileElevation) > 0.01) {
                           m_site->setElevation(m_weatherFileElevation);
                         } else {

--- a/src/openstudio_lib/LocationTabView.cpp
+++ b/src/openstudio_lib/LocationTabView.cpp
@@ -73,6 +73,7 @@
 #include <QCoreApplication>
 #include <QObject>
 #include <QPushButton>
+#include <span>
 
 static constexpr auto NAME("Name: ");
 static constexpr auto LATITUDE("Latitude: ");
@@ -470,7 +471,13 @@ LocationView::LocationView(bool isIP, const model::Model& model, const QString& 
                         m_site->setKeepSiteLocationInformation(true);
                         return m_site->setElevation(d);
                       }),
-                      boost::optional<NoFailAction>([this] { m_site->resetElevation(); }),
+                      boost::optional<NoFailAction>([this] {
+                        if (std::abs(m_weatherFileElevation) > 0.01) {
+                          m_site->setElevation(m_weatherFileElevation);
+                        } else {
+                          m_site->resetElevation();
+                        }
+                      }),
                       boost::none,                          // autosize
                       boost::none,                          // autocalculate
                       boost::optional<BasicQuery>([this] {  //

--- a/src/openstudio_lib/LocationTabView.cpp
+++ b/src/openstudio_lib/LocationTabView.cpp
@@ -175,6 +175,11 @@ LocationView::LocationView(bool isIP, const model::Model& model, const QString& 
   weatherFileGridLayout->setSpacing(7);
 
   // ***** Measure Tags GridLayout *****
+  auto* siteInfoGridLayout = new QGridLayout();
+  siteInfoGridLayout->setContentsMargins(7, 7, 7, 7);
+  siteInfoGridLayout->setSpacing(7);
+
+  // ***** Measure Tags GridLayout *****
   auto* measureTagsGridLayout = new QGridLayout();
   measureTagsGridLayout->setContentsMargins(7, 7, 7, 7);
   measureTagsGridLayout->setSpacing(7);
@@ -257,6 +262,41 @@ LocationView::LocationView(bool isIP, const model::Model& model, const QString& 
   weatherFileGridLayout->setColumnStretch(i, 10);
   leftVLayout->addLayout(weatherFileGridLayout);
   leftVLayout->addStretch();
+
+  // Site Information
+  {
+    label = new QLabel(tr("Site Information:"));
+    label->setObjectName("H2");
+    leftVLayout->addWidget(label);
+
+    int i = 0;
+
+    // Terrain
+    {
+      label = new QLabel(tr("Terrain"));
+      label->setToolTip("Terrain affects the wind speed at the site.");
+      label->setObjectName("StandardsInfo");
+
+      m_terrain = new QComboBox();
+      m_terrain->setFixedWidth(200);
+
+      siteInfoGridLayout->addWidget(label, i, 0);
+      siteInfoGridLayout->addWidget(m_terrain, i++, 1);
+      for (const std::string& terrain : model::Site::validTerrainValues()) {
+        m_terrain->addItem(toQString(terrain));
+      }
+      std::string terrainValue = m_site->terrain();
+      auto idx = m_terrain->findText(toQString(terrainValue));
+      OS_ASSERT(idx != -1);
+      m_terrain->setCurrentIndex(idx);
+      connect(m_terrain, static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentTextChanged), this, &LocationView::onTerrainChanged);
+    }
+
+    // ***** Site Info GridLayout *****
+    siteInfoGridLayout->setColumnStretch(++i, 10);
+    leftVLayout->addLayout(siteInfoGridLayout);
+    leftVLayout->addStretch();
+  }
 
   // ***** Climate Zones *****
   label = new QLabel(tr("Measure Tags (Optional):"));
@@ -898,6 +938,14 @@ void LocationView::checkNumDesignDays() {
     QMessageBox box(QMessageBox::Warning, tr("No Design Days in DDY File"),
                     tr("This DDY file does not contain any valid design days.  Check the DDY file itself for errors or omissions."), QMessageBox::Ok);
     box.exec();
+  }
+}
+
+void LocationView::onTerrainChanged(const QString& terrain) {
+  if (terrain.isEmpty()) {
+    m_site->resetTerrain();
+  } else {
+    m_site->setTerrain(toString(terrain));
   }
 }
 

--- a/src/openstudio_lib/LocationTabView.cpp
+++ b/src/openstudio_lib/LocationTabView.cpp
@@ -270,7 +270,7 @@ LocationView::LocationView(bool isIP, const model::Model& model, const QString& 
     label->setObjectName("H2");
     leftVLayout->addWidget(label);
 
-    int i = 0;
+    i = 0;
 
     {
       label = new QLabel(tr("Keep Site Location Information"));

--- a/src/openstudio_lib/LocationTabView.hpp
+++ b/src/openstudio_lib/LocationTabView.hpp
@@ -25,6 +25,8 @@ class EpwFile;
 class DesignDayGridView;
 class OSComboBox2;
 class OSItemSelectorButtons;
+class OSQuantityEdit2;
+class OSSwitch2;
 
 namespace model {
 class Model;
@@ -98,18 +100,22 @@ class LocationView : public QWidget
   YearSettingsWidget* m_yearSettingsWidget = nullptr;
   DesignDayGridView* m_designDaysGridView = nullptr;
   OSItemSelectorButtons* m_itemSelectorButtons = nullptr;
-  QString m_modelTempDir = QString();
-  QString m_lastEpwPathOpened = QString();
-  QString m_lastDdyPathOpened = QString();
-  OSComboBox2* m_terrain = nullptr;
-  QComboBox* m_ashraeClimateZone = nullptr;
-  QComboBox* m_cecClimateZone = nullptr;
+  QString m_modelTempDir;
+  QString m_lastEpwPathOpened;
+  QString m_lastDdyPathOpened;
+
+  QPushButton* m_weatherFileBtn = nullptr;
   QLineEdit* m_siteName = nullptr;
   QLabel* m_latitudeLbl = nullptr;
   QLabel* m_longitudeLbl = nullptr;
-  QLabel* m_elevationLbl = nullptr;
   QLabel* m_timeZoneLbl = nullptr;
-  QPushButton* m_weatherFileBtn = nullptr;
+
+  OSComboBox2* m_terrain = nullptr;
+  OSSwitch2* m_keepSiteLocationInfo = nullptr;
+  OSQuantityEdit2* m_elevation = nullptr;
+  QComboBox* m_ashraeClimateZone = nullptr;
+  QComboBox* m_cecClimateZone = nullptr;
+
   bool m_isIP;
 
  signals:

--- a/src/openstudio_lib/LocationTabView.hpp
+++ b/src/openstudio_lib/LocationTabView.hpp
@@ -113,6 +113,7 @@ class LocationView : public QWidget
   OSComboBox2* m_terrain = nullptr;
   OSSwitch2* m_keepSiteLocationInfo = nullptr;
   OSQuantityEdit2* m_elevation = nullptr;
+  double m_weatherFileElevation = 0.0;
   QComboBox* m_ashraeClimateZone = nullptr;
   QComboBox* m_cecClimateZone = nullptr;
 

--- a/src/openstudio_lib/LocationTabView.hpp
+++ b/src/openstudio_lib/LocationTabView.hpp
@@ -23,6 +23,7 @@ namespace openstudio {
 
 class EpwFile;
 class DesignDayGridView;
+class OSComboBox2;
 class OSItemSelectorButtons;
 
 namespace model {
@@ -100,7 +101,7 @@ class LocationView : public QWidget
   QString m_modelTempDir = QString();
   QString m_lastEpwPathOpened = QString();
   QString m_lastDdyPathOpened = QString();
-  QComboBox* m_terrain = nullptr;
+  OSComboBox2* m_terrain = nullptr;
   QComboBox* m_ashraeClimateZone = nullptr;
   QComboBox* m_cecClimateZone = nullptr;
   QLineEdit* m_siteName = nullptr;
@@ -154,8 +155,6 @@ class LocationView : public QWidget
   std::vector<openstudio::model::DesignDay> showDesignDaySelectionDialog(const std::vector<openstudio::model::DesignDay>& allDesignDays);
 
   void onDesignDayBtnClicked();
-
-  void onTerrainChanged(const QString& terrain);
 
   void onASHRAEClimateZoneChanged(const QString& climateZone);
 

--- a/src/openstudio_lib/LocationTabView.hpp
+++ b/src/openstudio_lib/LocationTabView.hpp
@@ -100,6 +100,7 @@ class LocationView : public QWidget
   QString m_modelTempDir = QString();
   QString m_lastEpwPathOpened = QString();
   QString m_lastDdyPathOpened = QString();
+  QComboBox* m_terrain = nullptr;
   QComboBox* m_ashraeClimateZone = nullptr;
   QComboBox* m_cecClimateZone = nullptr;
   QLineEdit* m_siteName = nullptr;
@@ -153,6 +154,8 @@ class LocationView : public QWidget
   std::vector<openstudio::model::DesignDay> showDesignDaySelectionDialog(const std::vector<openstudio::model::DesignDay>& allDesignDays);
 
   void onDesignDayBtnClicked();
+
+  void onTerrainChanged(const QString& terrain);
 
   void onASHRAEClimateZoneChanged(const QString& climateZone);
 

--- a/src/shared_gui_components/Component.cpp
+++ b/src/shared_gui_components/Component.cpp
@@ -430,17 +430,20 @@ void Component::createAbridgedLayout() {
   label = new QLabel(string);
   leftLayout->addWidget(label);
 
+  QString labelString;
+  QString typeString = "Unknown";
+  if (m_componentType == "component") {
+    labelString = "Type: ";
+  } else if (m_componentType == "measure" || m_componentType == "MeasureType") {
+    labelString = "Measure Type: ";
+  }
   for (const Attribute& attribute : m_attributes) {
     string = attribute.name().c_str();
     if (m_componentType == "component") {
       if (string.toStdString() == OPENSTUDIO_TYPE) {
         openstudio::AttributeValueType type = attribute.valueType();
         if (type == AttributeValueType::String) {
-          string = attribute.valueAsString().c_str();
-          QString temp("Type: ");
-          temp += string;
-          label = new QLabel(temp);
-          leftLayout->addWidget(label);
+          typeString = attribute.valueAsString().c_str();
           break;
         }
       }
@@ -448,15 +451,15 @@ void Component::createAbridgedLayout() {
       if (string.toStdString() == "Measure Type") {
         openstudio::AttributeValueType type = attribute.valueType();
         if (type == AttributeValueType::String) {
-          string = attribute.valueAsString().c_str();
-          QString temp("Measure Type: ");
-          temp += string;
-          label = new QLabel(temp);
-          leftLayout->addWidget(label);
+          typeString = attribute.valueAsString().c_str();
         }
       }
     }
   }
+
+  labelString += typeString;
+  label = new QLabel(labelString);
+  leftLayout->addWidget(label);
 
   m_msg = new QLabel(this);
   if (m_error) {

--- a/src/shared_gui_components/OSComboBox.cpp
+++ b/src/shared_gui_components/OSComboBox.cpp
@@ -250,6 +250,14 @@ void OSComboBox2::onModelObjectRemoved(const Handle& handle) {
   unbind();
 }
 
+void OSComboBox2::onActivated(int index) {
+  if (m_choiceConcept) {
+    if (index == this->currentIndex() && m_choiceConcept->isDefaulted()) {
+      this->onCurrentIndexChanged(this->currentText());
+    }
+  }
+}
+
 void OSComboBox2::onCurrentIndexChanged(const QString& text) {
   emit inFocus(m_focused, hasData());
 
@@ -347,6 +355,7 @@ void OSComboBox2::completeBind() {
     m_modelObject->getImpl<openstudio::model::detail::ModelObject_Impl>()
       ->onRemoveFromWorkspace.connect<OSComboBox2, &OSComboBox2::onModelObjectRemoved>(this);
 
+    connect(this, static_cast<void (OSComboBox2::*)(int)>(&OSComboBox2::activated), this, &OSComboBox2::onActivated);
     connect(this, static_cast<void (OSComboBox2::*)(const QString&)>(&OSComboBox2::currentTextChanged), this, &OSComboBox2::onCurrentIndexChanged);
 
     if (isEditable()) {

--- a/src/shared_gui_components/OSComboBox.hpp
+++ b/src/shared_gui_components/OSComboBox.hpp
@@ -180,6 +180,8 @@ class OSComboBox2
 
   void onModelObjectRemoved(const Handle& handle);
 
+  void onActivated(int index);
+
   void onCurrentIndexChanged(const QString& text);
 
   void onEditTextChanged(const QString& text);

--- a/src/shared_gui_components/OSQuantityEdit.cpp
+++ b/src/shared_gui_components/OSQuantityEdit.cpp
@@ -82,6 +82,10 @@ void OSQuantityEdit2::setLocked(bool locked) {
   m_lineEdit->setLocked(locked);
 }
 
+void OSQuantityEdit2::clearCachedText() {
+  m_text = "UNINITIALIZED";
+}
+
 QDoubleValidator* OSQuantityEdit2::doubleValidator() {
   return m_doubleValidator;
 }

--- a/src/shared_gui_components/OSQuantityEdit.hpp
+++ b/src/shared_gui_components/OSQuantityEdit.hpp
@@ -84,6 +84,8 @@ class OSQuantityEdit2
 
   void setLocked(bool locked);
 
+  void clearCachedText();
+
   QDoubleValidator* doubleValidator();
 
   void bind(bool isIP, const model::ModelObject& modelObject, DoubleGetter get, boost::optional<DoubleSetter> set = boost::none,


### PR DESCRIPTION
- Fix #825

* Smart Elevation
   * If you Tweak "Elevation", the "Keep Site Location Information" is automatically toggled on (or it won't be translated anyways)
   * Upon loading the Weather File, the Elevation is harcoded in the Site object but will show as being defaulted anyways (green)
   * If you reset elevation, it defaults back to the Weather File's elevation, not zero.



![825](https://github.com/user-attachments/assets/3482780a-3b5a-4ec7-8b5a-dc7d1e940aff)
