### PR TITLE
Add hot-gas reheat unitary system (Coil:Heating:Desuperheater)

### DIFF
--- a/src/openstudio_app/Resources/default/hvac_library.osm
+++ b/src/openstudio_app/Resources/default/hvac_library.osm
@@ -7011,7 +7011,7 @@ OS:Coil:Heating:Desuperheater,
 
 OS:AirLoopHVAC:UnitarySystem,
   {dbc42aea-40d9-42a6-9016-87cc16813b11}, !- Handle
-  Unitary - Single Speed DX cooling - Elec heat - CAV - Hotgas reheat, !- Name
+  Unitary - Single Speed DX cooling - Elec heat - CAV - Desuperheater reheat, !- Name
   Load,                                   !- Control Type
   ,                                       !- Controlling Zone or Thermostat Location
   CoolReheat,                             !- Dehumidification Control Type

--- a/src/openstudio_app/Resources/default/hvac_library.osm
+++ b/src/openstudio_app/Resources/default/hvac_library.osm
@@ -6999,6 +6999,64 @@ OS:AirLoopHVAC:UnitarySystem,
   ,                                       !- Heat Recovery Water Outlet Node Name
   ;                                       !- Design Specification Multispeed Object Name
 
+OS:Coil:Heating:Desuperheater,
+  {bdb03443-be0a-4953-8eb4-e6014bbced83}, !- Handle
+  Desuperheater Reheat Coil,              !- Name
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Availability Schedule Name
+  0.25,                                   !- Heat Reclaim Recovery Efficiency
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {983b9c20-5a9e-49eb-9770-5c1545cc6b65}, !- Heating Source Name
+  0;                                      !- On Cycle Parasitic Electric Load {W}
+
+OS:AirLoopHVAC:UnitarySystem,
+  {dbc42aea-40d9-42a6-9016-87cc16813b11}, !- Handle
+  Unitary - Single Speed DX cooling - Elec heat - CAV - Hotgas reheat, !- Name
+  Load,                                   !- Control Type
+  ,                                       !- Controlling Zone or Thermostat Location
+  CoolReheat,                             !- Dehumidification Control Type
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Availability Schedule Name
+  ,                                       !- Air Inlet Node Name
+  ,                                       !- Air Outlet Node Name
+  {0c016d27-85cb-4254-8b85-9a16c4586de5}, !- Supply Fan Name
+  BlowThrough,                            !- Fan Placement
+  {9f54092d-a4a8-41b8-a381-c4c332ecb843}, !- Supply Air Fan Operating Mode Schedule Name
+  {ca3b3fed-58b0-4f64-85f9-257f45d033a5}, !- Heating Coil Name
+  1,                                      !- DX Heating Coil Sizing Ratio
+  {983b9c20-5a9e-49eb-9770-5c1545cc6b65}, !- Cooling Coil Name
+  No,                                     !- Use DOAS DX Cooling Coil
+  2,                                      !- DOAS DX Cooling Coil Leaving Minimum Air Temperature {C}
+  LatentOrSensibleLoadControl,            !- Latent Load Control
+  {bdb03443-be0a-4953-8eb4-e6014bbced83}, !- Supplemental Heating Coil Name
+  SupplyAirFlowRate,                      !- Supply Air Flow Rate Method During Cooling Operation
+  autosize,                               !- Supply Air Flow Rate During Cooling Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area During Cooling Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation {m3/s-W}
+  SupplyAirFlowRate,                      !- Supply Air Flow Rate Method During Heating Operation
+  autosize,                               !- Supply Air Flow Rate During Heating Operation {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area during Heating Operation {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation {m3/s-W}
+  None,                                   !- Supply Air Flow Rate Method When No Cooling or Heating is Required
+  ,                                       !- Supply Air Flow Rate When No Cooling or Heating is Required {m3/s}
+  ,                                       !- Supply Air Flow Rate Per Floor Area When No Cooling or Heating is Required {m3/s-m2}
+  ,                                       !- Fraction of Autosized Design Cooling Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Fraction of Autosized Design Heating Supply Air Flow Rate When No Cooling or Heating is Required
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Cooling Operation When No Cooling or Heating is Required {m3/s-W}
+  ,                                       !- Design Supply Air Flow Rate Per Unit of Capacity During Heating Operation When No Cooling or Heating is Required {m3/s-W}
+  Yes,                                    !- No Load Supply Air Flow Rate Control Set To Low Speed
+  80,                                     !- Maximum Supply Air Temperature {C}
+  21,                                     !- Maximum Outdoor Dry-Bulb Temperature for Supplemental Heater Operation {C}
+  ,                                       !- Outdoor Dry-Bulb Temperature Sensor Node Name
+  0,                                      !- Ancilliary On-Cycle Electric Power {W}
+  0,                                      !- Ancilliary Off-Cycle Electric Power {W}
+  ,                                       !- Design Heat Recovery Water Flow Rate {m3/s}
+  80,                                     !- Maximum Temperature for Heat Recovery {C}
+  ,                                       !- Heat Recovery Water Inlet Node Name
+  ,                                       !- Heat Recovery Water Outlet Node Name
+  ;                                       !- Design Specification Multispeed Object Name
+
 OS:Fan:OnOff,
   {e803e540-d848-409c-9bad-0c0dc9c7b50a}, !- Handle
   Fan On Off 14,                          !- Name

--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -626,7 +626,7 @@ void remapLateralReferences(const model::ModelObject& original, model::ModelObje
 
 // `original` is the subtree that was cloned; `clonedObject` is its clone. Re-links any lateral
 // reference in the clone that still points into (or should point into) the original subtree.
-void fixupClonedReferences(const model::ModelObject& original, model::ModelObject clonedObject) {
+void fixupClonedReferences(const model::ModelObject& original, const model::ModelObject& clonedObject) {
   std::map<Handle, model::ModelObject> handleMap;
   buildCloneHandleMap(original, clonedObject, handleMap);
   remapLateralReferences(original, clonedObject, handleMap);

--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -92,10 +92,6 @@
 #include <openstudio/model/CoilHeatingElectric_Impl.hpp>
 #include <openstudio/model/CoilHeatingWater.hpp>
 #include <openstudio/model/CoilHeatingWater_Impl.hpp>
-#include <openstudio/model/CoilHeatingDesuperheater.hpp>
-#include <openstudio/model/CoilHeatingDesuperheater_Impl.hpp>
-#include <openstudio/model/AirLoopHVACUnitarySystem.hpp>
-#include <openstudio/model/AirLoopHVACUnitarySystem_Impl.hpp>
 #include <openstudio/model/ParentObject.hpp>
 #include <openstudio/model/ParentObject_Impl.hpp>
 #include <openstudio/model/Model.hpp>
@@ -131,6 +127,8 @@
 #include <openstudio/utilities/core/Assert.hpp>
 #include <openstudio/utilities/core/Compare.hpp>
 #include <openstudio/utilities/idd/OS_ComponentData_FieldEnums.hxx>
+
+#include <map>
 
 #include <QMessageBox>
 #include <QTimer>
@@ -526,30 +524,65 @@ void HVACLayoutController::addLibraryObjectToTopLevel(const OSItemId& itemId) {
 }
 
 namespace {
-  // ModelObject::clone() only remaps true parent-child ownership (children()), so it correctly
-  // duplicates a UnitarySystem's fan/coils. But CoilHeatingDesuperheater::heatingSource() is a
-  // lateral reference to a sibling coil rather than a child, so it is left unset by the clone.
-  // If that sibling is the unitary system's own cooling coil, re-link the clone to it.
-  // Walks the full cloned subtree since the UnitarySystem may be nested (e.g. cloning a whole
-  // AirLoopHVAC via "copy system") rather than being the clone root itself.
-  void fixupClonedDesuperheaterHeatingSource(model::ModelObject clonedObject) {
-    if (boost::optional<model::AirLoopHVACUnitarySystem> unitary = clonedObject.optionalCast<model::AirLoopHVACUnitarySystem>()) {
-      if (boost::optional<model::HVACComponent> supplementalCoil = unitary->supplementalHeatingCoil()) {
-        boost::optional<model::CoilHeatingDesuperheater> desuperheater = supplementalCoil->optionalCast<model::CoilHeatingDesuperheater>();
-        if (desuperheater && !desuperheater->heatingSource()) {
-          if (boost::optional<model::HVACComponent> coolingCoil = unitary->coolingCoil()) {
-            desuperheater->setHeatingSource(coolingCoil.get());
-          }
+  // ModelObject::clone() clones each child individually and reattaches it via setParent(), so
+  // true parent-child edges are correctly remapped to point within the new subtree. But children
+  // are cloned one at a time rather than as a batch sharing a single old->new handle table, so any
+  // *lateral* object-list reference between two siblings in the cloned subtree (e.g.
+  // CoilHeatingDesuperheater::heatingSource() pointing at a sibling cooling coil, or a
+  // SetpointManager's node references) is left pointing at the original objects instead of their
+  // clones. The functions below fix that up generically, for any object type, rather than special
+  // casing each lateral-reference field as it's discovered.
+
+  // Walks `original` and `clone` in parallel -- children() order is deterministic and preserved by
+  // clone() -- building a map from each original object's handle to its corresponding clone.
+  void buildCloneHandleMap(const model::ModelObject& original, const model::ModelObject& clone,
+                            std::map<Handle, model::ModelObject>& handleMap) {
+    handleMap.emplace(original.handle(), clone);
+
+    boost::optional<model::ParentObject> originalParent = original.optionalCast<model::ParentObject>();
+    boost::optional<model::ParentObject> cloneParent = clone.optionalCast<model::ParentObject>();
+    if (originalParent && cloneParent) {
+      std::vector<model::ModelObject> originalChildren = originalParent->children();
+      std::vector<model::ModelObject> cloneChildren = cloneParent->children();
+      if (originalChildren.size() == cloneChildren.size()) {
+        for (size_t i = 0; i < originalChildren.size(); ++i) {
+          buildCloneHandleMap(originalChildren[i], cloneChildren[i], handleMap);
         }
       }
     }
+  }
 
-    // children() is declared on ParentObject, not the generic ModelObject, so cast before recursing.
-    if (boost::optional<model::ParentObject> parent = clonedObject.optionalCast<model::ParentObject>()) {
-      for (const model::ModelObject& child : parent->children()) {
-        fixupClonedDesuperheaterHeatingSource(child);
+  // Rewrites every object-list field on clonedObject (and recursively its children) that still
+  // points at an object handleMap has a clone for, to point at that clone instead.
+  void remapLateralReferences(model::ModelObject clonedObject, const std::map<Handle, model::ModelObject>& handleMap) {
+    IddObject iddObject = clonedObject.iddObject();
+    for (unsigned index = 0; index < clonedObject.numFields(); ++index) {
+      if (iddObject.objectLists(index).empty()) {
+        continue;
+      }
+      boost::optional<WorkspaceObject> target = clonedObject.getTarget(index);
+      if (!target) {
+        continue;
+      }
+      auto it = handleMap.find(target->handle());
+      if (it != handleMap.end() && it->second.handle() != target->handle()) {
+        clonedObject.setPointer(index, it->second.handle());
       }
     }
+
+    if (boost::optional<model::ParentObject> parent = clonedObject.optionalCast<model::ParentObject>()) {
+      for (const model::ModelObject& child : parent->children()) {
+        remapLateralReferences(child, handleMap);
+      }
+    }
+  }
+
+  // `original` is the subtree that was cloned; `clonedObject` is its clone. Re-links any lateral
+  // reference in the clone that still points into the original subtree.
+  void fixupClonedReferences(const model::ModelObject& original, model::ModelObject clonedObject) {
+    std::map<Handle, model::ModelObject> handleMap;
+    buildCloneHandleMap(original, clonedObject, handleMap);
+    remapLateralReferences(clonedObject, handleMap);
   }
 }  // namespace
 
@@ -561,8 +594,9 @@ void HVACLayoutController::addLibraryObjectToModelNode(const OSItemId& itemId, m
   object = doc->getModelObject(itemId);
   if (object) {
     if (!doc->fromModel(itemId)) {
+      model::ModelObject original = object.get();
       object = object->clone(comp.model());
-      fixupClonedDesuperheaterHeatingSource(object.get());
+      fixupClonedReferences(original, object.get());
       remove = true;
     }
   }
@@ -928,7 +962,7 @@ void HVACSystemsController::onCopySystemClicked() {
   auto loop = currentLoop();
   if (loop) {
     auto clone = loop->clone(loop->model());
-    fixupClonedDesuperheaterHeatingSource(clone);
+    fixupClonedReferences(loop.get(), clone);
     setCurrentHandle(toQString(clone.handle()));
   }
 }

--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -529,9 +529,10 @@ namespace {
   // are cloned one at a time rather than as a batch sharing a single old->new handle table, so any
   // *lateral* object-list reference between two siblings in the cloned subtree (e.g.
   // CoilHeatingDesuperheater::heatingSource() pointing at a sibling cooling coil, or a
-  // SetpointManager's node references) is left pointing at the original objects instead of their
-  // clones. The functions below fix that up generically, for any object type, rather than special
-  // casing each lateral-reference field as it's discovered.
+  // SetpointManager's node references) is left broken on the clone -- for some field/type
+  // combinations still pointing at the original object, for others (empirically, heatingSource())
+  // cleared to empty outright. The functions below fix that up generically, for any object type,
+  // rather than special casing each lateral-reference field as it's discovered.
 
   // Walks `original` and `clone` in parallel -- children() order is deterministic and preserved by
   // clone() -- building a map from each original object's handle to its corresponding clone.
@@ -552,37 +553,53 @@ namespace {
     }
   }
 
-  // Rewrites every object-list field on clonedObject (and recursively its children) that still
-  // points at an object handleMap has a clone for, to point at that clone instead.
-  void remapLateralReferences(model::ModelObject clonedObject, const std::map<Handle, model::ModelObject>& handleMap) {
-    IddObject iddObject = clonedObject.iddObject();
-    for (unsigned index = 0; index < clonedObject.numFields(); ++index) {
+  // For every lateral object-list field on `original` whose target was itself cloned (i.e. has an
+  // entry in handleMap), forces the corresponding field on `clonedObject` to point at that clone.
+  // Fields are read from `original`, not from `clonedObject`: clone() doesn't necessarily leave a
+  // lateral reference pointing at the stale original object -- for CoilHeatingDesuperheater's
+  // heatingSource() it clears the field outright -- so the only reliable source of "what this
+  // field is supposed to point at" is the original.
+  void remapLateralReferences(const model::ModelObject& original, model::ModelObject clonedObject,
+                               const std::map<Handle, model::ModelObject>& handleMap) {
+    IddObject iddObject = original.iddObject();
+    for (unsigned index = 0; index < original.numFields(); ++index) {
       if (iddObject.objectLists(index).empty()) {
         continue;
       }
-      boost::optional<WorkspaceObject> target = clonedObject.getTarget(index);
-      if (!target) {
+      boost::optional<WorkspaceObject> originalTarget = original.getTarget(index);
+      if (!originalTarget) {
         continue;
       }
-      auto it = handleMap.find(target->handle());
-      if (it != handleMap.end() && it->second.handle() != target->handle()) {
-        clonedObject.setPointer(index, it->second.handle());
+      auto it = handleMap.find(originalTarget->handle());
+      if (it == handleMap.end()) {
+        continue;
       }
+      boost::optional<WorkspaceObject> clonedTarget = clonedObject.getTarget(index);
+      if (clonedTarget && clonedTarget->handle() == it->second.handle()) {
+        continue;
+      }
+      clonedObject.setPointer(index, it->second.handle());
     }
 
-    if (boost::optional<model::ParentObject> parent = clonedObject.optionalCast<model::ParentObject>()) {
-      for (const model::ModelObject& child : parent->children()) {
-        remapLateralReferences(child, handleMap);
+    boost::optional<model::ParentObject> originalParent = original.optionalCast<model::ParentObject>();
+    boost::optional<model::ParentObject> cloneParent = clonedObject.optionalCast<model::ParentObject>();
+    if (originalParent && cloneParent) {
+      std::vector<model::ModelObject> originalChildren = originalParent->children();
+      std::vector<model::ModelObject> cloneChildren = cloneParent->children();
+      if (originalChildren.size() == cloneChildren.size()) {
+        for (size_t i = 0; i < originalChildren.size(); ++i) {
+          remapLateralReferences(originalChildren[i], cloneChildren[i], handleMap);
+        }
       }
     }
   }
 
   // `original` is the subtree that was cloned; `clonedObject` is its clone. Re-links any lateral
-  // reference in the clone that still points into the original subtree.
+  // reference in the clone that still points into (or should point into) the original subtree.
   void fixupClonedReferences(const model::ModelObject& original, model::ModelObject clonedObject) {
     std::map<Handle, model::ModelObject> handleMap;
     buildCloneHandleMap(original, clonedObject, handleMap);
-    remapLateralReferences(clonedObject, handleMap);
+    remapLateralReferences(original, clonedObject, handleMap);
   }
 }  // namespace
 

--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -534,17 +534,43 @@ namespace {
   // cleared to empty outright. The functions below fix that up generically, for any object type,
   // rather than special casing each lateral-reference field as it's discovered.
 
-  // Walks `original` and `clone` in parallel -- children() order is deterministic and preserved by
-  // clone() -- building a map from each original object's handle to its corresponding clone.
+  // ParentObject::children() is true ownership (e.g. a UnitarySystem's fan/coils) but does *not*
+  // include HVACComponents placed on a Loop's supply/demand branches -- a UnitarySystem sitting on
+  // an AirLoopHVAC's supply branch is reachable via supplyComponents(), not children(). Cloning a
+  // whole loop (the "copy system" toolbar action) needs both, or the branch equipment -- and
+  // anything lateral-referenced from inside it, like the desuperheater's heating source -- is
+  // never visited at all.
+  //
+  // Returned as separate groups (children / supplyComponents / demandComponents), each matched and
+  // recursed into independently: cloning a loop does not carry over the connected thermal zones on
+  // the demand side, so original vs. clone demandComponents() can legitimately have different
+  // sizes. Treating everything as one combined list would let a benign demand-side mismatch abort
+  // recursion into the supply side too, where the equipment (and lateral references like the
+  // desuperheater's heating source) *does* line up 1:1 with the original.
+  std::vector<std::vector<model::ModelObject>> childSubtreeObjectGroups(const model::ModelObject& object) {
+    std::vector<std::vector<model::ModelObject>> groups;
+    if (boost::optional<model::Loop> loop = object.optionalCast<model::Loop>()) {
+      groups.push_back(loop->supplyComponents());
+      groups.push_back(loop->demandComponents());
+    }
+    if (boost::optional<model::ParentObject> parent = object.optionalCast<model::ParentObject>()) {
+      groups.push_back(parent->children());
+    }
+    return groups;
+  }
+
+  // Walks `original` and `clone` in parallel -- childSubtreeObjectGroups() order is deterministic
+  // and preserved by clone() -- building a map from each original object's handle to its
+  // corresponding clone.
   void buildCloneHandleMap(const model::ModelObject& original, const model::ModelObject& clone,
                             std::map<Handle, model::ModelObject>& handleMap) {
     handleMap.emplace(original.handle(), clone);
 
-    boost::optional<model::ParentObject> originalParent = original.optionalCast<model::ParentObject>();
-    boost::optional<model::ParentObject> cloneParent = clone.optionalCast<model::ParentObject>();
-    if (originalParent && cloneParent) {
-      std::vector<model::ModelObject> originalChildren = originalParent->children();
-      std::vector<model::ModelObject> cloneChildren = cloneParent->children();
+    std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
+    std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clone);
+    for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
+      const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
+      const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
       if (originalChildren.size() == cloneChildren.size()) {
         for (size_t i = 0; i < originalChildren.size(); ++i) {
           buildCloneHandleMap(originalChildren[i], cloneChildren[i], handleMap);
@@ -581,11 +607,11 @@ namespace {
       clonedObject.setPointer(index, it->second.handle());
     }
 
-    boost::optional<model::ParentObject> originalParent = original.optionalCast<model::ParentObject>();
-    boost::optional<model::ParentObject> cloneParent = clonedObject.optionalCast<model::ParentObject>();
-    if (originalParent && cloneParent) {
-      std::vector<model::ModelObject> originalChildren = originalParent->children();
-      std::vector<model::ModelObject> cloneChildren = cloneParent->children();
+    std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
+    std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clonedObject);
+    for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
+      const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
+      const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
       if (originalChildren.size() == cloneChildren.size()) {
         for (size_t i = 0; i < originalChildren.size(); ++i) {
           remapLateralReferences(originalChildren[i], cloneChildren[i], handleMap);

--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -92,6 +92,12 @@
 #include <openstudio/model/CoilHeatingElectric_Impl.hpp>
 #include <openstudio/model/CoilHeatingWater.hpp>
 #include <openstudio/model/CoilHeatingWater_Impl.hpp>
+#include <openstudio/model/CoilHeatingDesuperheater.hpp>
+#include <openstudio/model/CoilHeatingDesuperheater_Impl.hpp>
+#include <openstudio/model/AirLoopHVACUnitarySystem.hpp>
+#include <openstudio/model/AirLoopHVACUnitarySystem_Impl.hpp>
+#include <openstudio/model/ParentObject.hpp>
+#include <openstudio/model/ParentObject_Impl.hpp>
 #include <openstudio/model/Model.hpp>
 #include <openstudio/model/Model_Impl.hpp>
 #include <openstudio/model/Node.hpp>
@@ -519,6 +525,34 @@ void HVACLayoutController::addLibraryObjectToTopLevel(const OSItemId& itemId) {
   message.exec();
 }
 
+namespace {
+  // ModelObject::clone() only remaps true parent-child ownership (children()), so it correctly
+  // duplicates a UnitarySystem's fan/coils. But CoilHeatingDesuperheater::heatingSource() is a
+  // lateral reference to a sibling coil rather than a child, so it is left unset by the clone.
+  // If that sibling is the unitary system's own cooling coil, re-link the clone to it.
+  // Walks the full cloned subtree since the UnitarySystem may be nested (e.g. cloning a whole
+  // AirLoopHVAC via "copy system") rather than being the clone root itself.
+  void fixupClonedDesuperheaterHeatingSource(model::ModelObject clonedObject) {
+    if (boost::optional<model::AirLoopHVACUnitarySystem> unitary = clonedObject.optionalCast<model::AirLoopHVACUnitarySystem>()) {
+      if (boost::optional<model::HVACComponent> supplementalCoil = unitary->supplementalHeatingCoil()) {
+        boost::optional<model::CoilHeatingDesuperheater> desuperheater = supplementalCoil->optionalCast<model::CoilHeatingDesuperheater>();
+        if (desuperheater && !desuperheater->heatingSource()) {
+          if (boost::optional<model::HVACComponent> coolingCoil = unitary->coolingCoil()) {
+            desuperheater->setHeatingSource(coolingCoil.get());
+          }
+        }
+      }
+    }
+
+    // children() is declared on ParentObject, not the generic ModelObject, so cast before recursing.
+    if (boost::optional<model::ParentObject> parent = clonedObject.optionalCast<model::ParentObject>()) {
+      for (const model::ModelObject& child : parent->children()) {
+        fixupClonedDesuperheaterHeatingSource(child);
+      }
+    }
+  }
+}  // namespace
+
 void HVACLayoutController::addLibraryObjectToModelNode(const OSItemId& itemId, model::HVACComponent& comp) {
   model::OptionalModelObject object;
   bool remove = false;
@@ -528,6 +562,7 @@ void HVACLayoutController::addLibraryObjectToModelNode(const OSItemId& itemId, m
   if (object) {
     if (!doc->fromModel(itemId)) {
       object = object->clone(comp.model());
+      fixupClonedDesuperheaterHeatingSource(object.get());
       remove = true;
     }
   }
@@ -893,6 +928,7 @@ void HVACSystemsController::onCopySystemClicked() {
   auto loop = currentLoop();
   if (loop) {
     auto clone = loop->clone(loop->model());
+    fixupClonedDesuperheaterHeatingSource(clone);
     setCurrentHandle(toQString(clone.handle()));
   }
 }

--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -536,22 +536,27 @@ namespace {
 
   // ParentObject::children() is true ownership (e.g. a UnitarySystem's fan/coils) but does *not*
   // include HVACComponents placed on a Loop's supply/demand branches -- a UnitarySystem sitting on
-  // an AirLoopHVAC's supply branch is reachable via supplyComponents(), not children(). Cloning a
-  // whole loop (the "copy system" toolbar action) needs both, or the branch equipment -- and
-  // anything lateral-referenced from inside it, like the desuperheater's heating source -- is
-  // never visited at all.
+  // an AirLoopHVAC's supply branch is reachable via supplyComponents(), not children(). The same
+  // gap exists one level deeper: equipment on an AirLoopHVACOutdoorAirSystem's outdoor-air/relief
+  // branches (e.g. an evaporative cooler, or a SetpointManager:MixedAir sitting on one of those
+  // nodes) is reachable only via oaComponents()/reliefComponents(), not children() either. Cloning
+  // a whole loop (the "copy system" toolbar action) needs all of these, or the branch equipment --
+  // and anything lateral-referenced from inside it -- is never visited at all.
   //
-  // Returned as separate groups (children / supplyComponents / demandComponents), each matched and
-  // recursed into independently: cloning a loop does not carry over the connected thermal zones on
-  // the demand side, so original vs. clone demandComponents() can legitimately have different
-  // sizes. Treating everything as one combined list would let a benign demand-side mismatch abort
-  // recursion into the supply side too, where the equipment (and lateral references like the
-  // desuperheater's heating source) *does* line up 1:1 with the original.
+  // Returned as separate groups, each matched and recursed into independently: cloning a loop does
+  // not carry over the connected thermal zones on the demand side, so original vs. clone
+  // demandComponents() can legitimately have different sizes. Treating everything as one combined
+  // list would let a benign demand-side mismatch abort recursion into the other groups too, where
+  // the equipment (and any lateral references inside it) *does* line up 1:1 with the original.
   std::vector<std::vector<model::ModelObject>> childSubtreeObjectGroups(const model::ModelObject& object) {
     std::vector<std::vector<model::ModelObject>> groups;
     if (boost::optional<model::Loop> loop = object.optionalCast<model::Loop>()) {
       groups.push_back(loop->supplyComponents());
       groups.push_back(loop->demandComponents());
+    }
+    if (boost::optional<model::AirLoopHVACOutdoorAirSystem> oaSystem = object.optionalCast<model::AirLoopHVACOutdoorAirSystem>()) {
+      groups.push_back(oaSystem->oaComponents());
+      groups.push_back(oaSystem->reliefComponents());
     }
     if (boost::optional<model::ParentObject> parent = object.optionalCast<model::ParentObject>()) {
       groups.push_back(parent->children());

--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -22,6 +22,7 @@
 #include "HorizontalTabWidget.hpp"
 #include "MainRightColumnController.hpp"
 #include "../shared_gui_components/OSViewSwitcher.hpp"
+#include "../utilities/CloneFixup.hpp"
 
 #include <openstudio/model/ModelObject.hpp>
 #include <openstudio/model/HVACComponent.hpp>
@@ -522,116 +523,6 @@ void HVACLayoutController::addLibraryObjectToTopLevel(const OSItemId& itemId) {
 
   message.exec();
 }
-
-namespace {
-// ModelObject::clone() clones each child individually and reattaches it via setParent(), so
-// true parent-child edges are correctly remapped to point within the new subtree. But children
-// are cloned one at a time rather than as a batch sharing a single old->new handle table, so any
-// *lateral* object-list reference between two siblings in the cloned subtree (e.g.
-// CoilHeatingDesuperheater::heatingSource() pointing at a sibling cooling coil, or a
-// SetpointManager's node references) is left broken on the clone -- for some field/type
-// combinations still pointing at the original object, for others (empirically, heatingSource())
-// cleared to empty outright. The functions below fix that up generically, for any object type,
-// rather than special casing each lateral-reference field as it's discovered.
-
-// ParentObject::children() is true ownership (e.g. a UnitarySystem's fan/coils) but does *not*
-// include HVACComponents placed on a Loop's supply/demand branches -- a UnitarySystem sitting on
-// an AirLoopHVAC's supply branch is reachable via supplyComponents(), not children(). The same
-// gap exists one level deeper: equipment on an AirLoopHVACOutdoorAirSystem's outdoor-air/relief
-// branches (e.g. an evaporative cooler, or a SetpointManager:MixedAir sitting on one of those
-// nodes) is reachable only via oaComponents()/reliefComponents(), not children() either. Cloning
-// a whole loop (the "copy system" toolbar action) needs all of these, or the branch equipment --
-// and anything lateral-referenced from inside it -- is never visited at all.
-//
-// Returned as separate groups, each matched and recursed into independently: cloning a loop does
-// not carry over the connected thermal zones on the demand side, so original vs. clone
-// demandComponents() can legitimately have different sizes. Treating everything as one combined
-// list would let a benign demand-side mismatch abort recursion into the other groups too, where
-// the equipment (and any lateral references inside it) *does* line up 1:1 with the original.
-std::vector<std::vector<model::ModelObject>> childSubtreeObjectGroups(const model::ModelObject& object) {
-  std::vector<std::vector<model::ModelObject>> groups;
-  if (boost::optional<model::Loop> loop = object.optionalCast<model::Loop>()) {
-    groups.push_back(loop->supplyComponents());
-    groups.push_back(loop->demandComponents());
-  }
-  if (boost::optional<model::AirLoopHVACOutdoorAirSystem> oaSystem = object.optionalCast<model::AirLoopHVACOutdoorAirSystem>()) {
-    groups.push_back(oaSystem->oaComponents());
-    groups.push_back(oaSystem->reliefComponents());
-  }
-  if (boost::optional<model::ParentObject> parent = object.optionalCast<model::ParentObject>()) {
-    groups.push_back(parent->children());
-  }
-  return groups;
-}
-
-// Walks `original` and `clone` in parallel -- childSubtreeObjectGroups() order is deterministic
-// and preserved by clone() -- building a map from each original object's handle to its
-// corresponding clone.
-void buildCloneHandleMap(const model::ModelObject& original, const model::ModelObject& clone, std::map<Handle, model::ModelObject>& handleMap) {
-  handleMap.emplace(original.handle(), clone);
-
-  std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
-  std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clone);
-  for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
-    const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
-    const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
-    if (originalChildren.size() == cloneChildren.size()) {
-      for (size_t i = 0; i < originalChildren.size(); ++i) {
-        buildCloneHandleMap(originalChildren[i], cloneChildren[i], handleMap);
-      }
-    }
-  }
-}
-
-// For every lateral object-list field on `original` whose target was itself cloned (i.e. has an
-// entry in handleMap), forces the corresponding field on `clonedObject` to point at that clone.
-// Fields are read from `original`, not from `clonedObject`: clone() doesn't necessarily leave a
-// lateral reference pointing at the stale original object -- for CoilHeatingDesuperheater's
-// heatingSource() it clears the field outright -- so the only reliable source of "what this
-// field is supposed to point at" is the original.
-void remapLateralReferences(const model::ModelObject& original, model::ModelObject clonedObject,
-                            const std::map<Handle, model::ModelObject>& handleMap) {
-  IddObject iddObject = original.iddObject();
-  for (unsigned index = 0; index < original.numFields(); ++index) {
-    if (iddObject.objectLists(index).empty()) {
-      continue;
-    }
-    boost::optional<WorkspaceObject> originalTarget = original.getTarget(index);
-    if (!originalTarget) {
-      continue;
-    }
-    auto it = handleMap.find(originalTarget->handle());
-    if (it == handleMap.end()) {
-      continue;
-    }
-    boost::optional<WorkspaceObject> clonedTarget = clonedObject.getTarget(index);
-    if (clonedTarget && clonedTarget->handle() == it->second.handle()) {
-      continue;
-    }
-    clonedObject.setPointer(index, it->second.handle());
-  }
-
-  std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
-  std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clonedObject);
-  for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
-    const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
-    const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
-    if (originalChildren.size() == cloneChildren.size()) {
-      for (size_t i = 0; i < originalChildren.size(); ++i) {
-        remapLateralReferences(originalChildren[i], cloneChildren[i], handleMap);
-      }
-    }
-  }
-}
-
-// `original` is the subtree that was cloned; `clonedObject` is its clone. Re-links any lateral
-// reference in the clone that still points into (or should point into) the original subtree.
-void fixupClonedReferences(const model::ModelObject& original, const model::ModelObject& clonedObject) {
-  std::map<Handle, model::ModelObject> handleMap;
-  buildCloneHandleMap(original, clonedObject, handleMap);
-  remapLateralReferences(original, clonedObject, handleMap);
-}
-}  // namespace
 
 void HVACLayoutController::addLibraryObjectToModelNode(const OSItemId& itemId, model::HVACComponent& comp) {
   model::OptionalModelObject object;

--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -524,114 +524,113 @@ void HVACLayoutController::addLibraryObjectToTopLevel(const OSItemId& itemId) {
 }
 
 namespace {
-  // ModelObject::clone() clones each child individually and reattaches it via setParent(), so
-  // true parent-child edges are correctly remapped to point within the new subtree. But children
-  // are cloned one at a time rather than as a batch sharing a single old->new handle table, so any
-  // *lateral* object-list reference between two siblings in the cloned subtree (e.g.
-  // CoilHeatingDesuperheater::heatingSource() pointing at a sibling cooling coil, or a
-  // SetpointManager's node references) is left broken on the clone -- for some field/type
-  // combinations still pointing at the original object, for others (empirically, heatingSource())
-  // cleared to empty outright. The functions below fix that up generically, for any object type,
-  // rather than special casing each lateral-reference field as it's discovered.
+// ModelObject::clone() clones each child individually and reattaches it via setParent(), so
+// true parent-child edges are correctly remapped to point within the new subtree. But children
+// are cloned one at a time rather than as a batch sharing a single old->new handle table, so any
+// *lateral* object-list reference between two siblings in the cloned subtree (e.g.
+// CoilHeatingDesuperheater::heatingSource() pointing at a sibling cooling coil, or a
+// SetpointManager's node references) is left broken on the clone -- for some field/type
+// combinations still pointing at the original object, for others (empirically, heatingSource())
+// cleared to empty outright. The functions below fix that up generically, for any object type,
+// rather than special casing each lateral-reference field as it's discovered.
 
-  // ParentObject::children() is true ownership (e.g. a UnitarySystem's fan/coils) but does *not*
-  // include HVACComponents placed on a Loop's supply/demand branches -- a UnitarySystem sitting on
-  // an AirLoopHVAC's supply branch is reachable via supplyComponents(), not children(). The same
-  // gap exists one level deeper: equipment on an AirLoopHVACOutdoorAirSystem's outdoor-air/relief
-  // branches (e.g. an evaporative cooler, or a SetpointManager:MixedAir sitting on one of those
-  // nodes) is reachable only via oaComponents()/reliefComponents(), not children() either. Cloning
-  // a whole loop (the "copy system" toolbar action) needs all of these, or the branch equipment --
-  // and anything lateral-referenced from inside it -- is never visited at all.
-  //
-  // Returned as separate groups, each matched and recursed into independently: cloning a loop does
-  // not carry over the connected thermal zones on the demand side, so original vs. clone
-  // demandComponents() can legitimately have different sizes. Treating everything as one combined
-  // list would let a benign demand-side mismatch abort recursion into the other groups too, where
-  // the equipment (and any lateral references inside it) *does* line up 1:1 with the original.
-  std::vector<std::vector<model::ModelObject>> childSubtreeObjectGroups(const model::ModelObject& object) {
-    std::vector<std::vector<model::ModelObject>> groups;
-    if (boost::optional<model::Loop> loop = object.optionalCast<model::Loop>()) {
-      groups.push_back(loop->supplyComponents());
-      groups.push_back(loop->demandComponents());
-    }
-    if (boost::optional<model::AirLoopHVACOutdoorAirSystem> oaSystem = object.optionalCast<model::AirLoopHVACOutdoorAirSystem>()) {
-      groups.push_back(oaSystem->oaComponents());
-      groups.push_back(oaSystem->reliefComponents());
-    }
-    if (boost::optional<model::ParentObject> parent = object.optionalCast<model::ParentObject>()) {
-      groups.push_back(parent->children());
-    }
-    return groups;
+// ParentObject::children() is true ownership (e.g. a UnitarySystem's fan/coils) but does *not*
+// include HVACComponents placed on a Loop's supply/demand branches -- a UnitarySystem sitting on
+// an AirLoopHVAC's supply branch is reachable via supplyComponents(), not children(). The same
+// gap exists one level deeper: equipment on an AirLoopHVACOutdoorAirSystem's outdoor-air/relief
+// branches (e.g. an evaporative cooler, or a SetpointManager:MixedAir sitting on one of those
+// nodes) is reachable only via oaComponents()/reliefComponents(), not children() either. Cloning
+// a whole loop (the "copy system" toolbar action) needs all of these, or the branch equipment --
+// and anything lateral-referenced from inside it -- is never visited at all.
+//
+// Returned as separate groups, each matched and recursed into independently: cloning a loop does
+// not carry over the connected thermal zones on the demand side, so original vs. clone
+// demandComponents() can legitimately have different sizes. Treating everything as one combined
+// list would let a benign demand-side mismatch abort recursion into the other groups too, where
+// the equipment (and any lateral references inside it) *does* line up 1:1 with the original.
+std::vector<std::vector<model::ModelObject>> childSubtreeObjectGroups(const model::ModelObject& object) {
+  std::vector<std::vector<model::ModelObject>> groups;
+  if (boost::optional<model::Loop> loop = object.optionalCast<model::Loop>()) {
+    groups.push_back(loop->supplyComponents());
+    groups.push_back(loop->demandComponents());
   }
+  if (boost::optional<model::AirLoopHVACOutdoorAirSystem> oaSystem = object.optionalCast<model::AirLoopHVACOutdoorAirSystem>()) {
+    groups.push_back(oaSystem->oaComponents());
+    groups.push_back(oaSystem->reliefComponents());
+  }
+  if (boost::optional<model::ParentObject> parent = object.optionalCast<model::ParentObject>()) {
+    groups.push_back(parent->children());
+  }
+  return groups;
+}
 
-  // Walks `original` and `clone` in parallel -- childSubtreeObjectGroups() order is deterministic
-  // and preserved by clone() -- building a map from each original object's handle to its
-  // corresponding clone.
-  void buildCloneHandleMap(const model::ModelObject& original, const model::ModelObject& clone,
-                            std::map<Handle, model::ModelObject>& handleMap) {
-    handleMap.emplace(original.handle(), clone);
+// Walks `original` and `clone` in parallel -- childSubtreeObjectGroups() order is deterministic
+// and preserved by clone() -- building a map from each original object's handle to its
+// corresponding clone.
+void buildCloneHandleMap(const model::ModelObject& original, const model::ModelObject& clone, std::map<Handle, model::ModelObject>& handleMap) {
+  handleMap.emplace(original.handle(), clone);
 
-    std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
-    std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clone);
-    for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
-      const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
-      const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
-      if (originalChildren.size() == cloneChildren.size()) {
-        for (size_t i = 0; i < originalChildren.size(); ++i) {
-          buildCloneHandleMap(originalChildren[i], cloneChildren[i], handleMap);
-        }
+  std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
+  std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clone);
+  for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
+    const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
+    const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
+    if (originalChildren.size() == cloneChildren.size()) {
+      for (size_t i = 0; i < originalChildren.size(); ++i) {
+        buildCloneHandleMap(originalChildren[i], cloneChildren[i], handleMap);
       }
     }
   }
+}
 
-  // For every lateral object-list field on `original` whose target was itself cloned (i.e. has an
-  // entry in handleMap), forces the corresponding field on `clonedObject` to point at that clone.
-  // Fields are read from `original`, not from `clonedObject`: clone() doesn't necessarily leave a
-  // lateral reference pointing at the stale original object -- for CoilHeatingDesuperheater's
-  // heatingSource() it clears the field outright -- so the only reliable source of "what this
-  // field is supposed to point at" is the original.
-  void remapLateralReferences(const model::ModelObject& original, model::ModelObject clonedObject,
-                               const std::map<Handle, model::ModelObject>& handleMap) {
-    IddObject iddObject = original.iddObject();
-    for (unsigned index = 0; index < original.numFields(); ++index) {
-      if (iddObject.objectLists(index).empty()) {
-        continue;
-      }
-      boost::optional<WorkspaceObject> originalTarget = original.getTarget(index);
-      if (!originalTarget) {
-        continue;
-      }
-      auto it = handleMap.find(originalTarget->handle());
-      if (it == handleMap.end()) {
-        continue;
-      }
-      boost::optional<WorkspaceObject> clonedTarget = clonedObject.getTarget(index);
-      if (clonedTarget && clonedTarget->handle() == it->second.handle()) {
-        continue;
-      }
-      clonedObject.setPointer(index, it->second.handle());
+// For every lateral object-list field on `original` whose target was itself cloned (i.e. has an
+// entry in handleMap), forces the corresponding field on `clonedObject` to point at that clone.
+// Fields are read from `original`, not from `clonedObject`: clone() doesn't necessarily leave a
+// lateral reference pointing at the stale original object -- for CoilHeatingDesuperheater's
+// heatingSource() it clears the field outright -- so the only reliable source of "what this
+// field is supposed to point at" is the original.
+void remapLateralReferences(const model::ModelObject& original, model::ModelObject clonedObject,
+                            const std::map<Handle, model::ModelObject>& handleMap) {
+  IddObject iddObject = original.iddObject();
+  for (unsigned index = 0; index < original.numFields(); ++index) {
+    if (iddObject.objectLists(index).empty()) {
+      continue;
     }
+    boost::optional<WorkspaceObject> originalTarget = original.getTarget(index);
+    if (!originalTarget) {
+      continue;
+    }
+    auto it = handleMap.find(originalTarget->handle());
+    if (it == handleMap.end()) {
+      continue;
+    }
+    boost::optional<WorkspaceObject> clonedTarget = clonedObject.getTarget(index);
+    if (clonedTarget && clonedTarget->handle() == it->second.handle()) {
+      continue;
+    }
+    clonedObject.setPointer(index, it->second.handle());
+  }
 
-    std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
-    std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clonedObject);
-    for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
-      const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
-      const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
-      if (originalChildren.size() == cloneChildren.size()) {
-        for (size_t i = 0; i < originalChildren.size(); ++i) {
-          remapLateralReferences(originalChildren[i], cloneChildren[i], handleMap);
-        }
+  std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
+  std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clonedObject);
+  for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
+    const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
+    const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
+    if (originalChildren.size() == cloneChildren.size()) {
+      for (size_t i = 0; i < originalChildren.size(); ++i) {
+        remapLateralReferences(originalChildren[i], cloneChildren[i], handleMap);
       }
     }
   }
+}
 
-  // `original` is the subtree that was cloned; `clonedObject` is its clone. Re-links any lateral
-  // reference in the clone that still points into (or should point into) the original subtree.
-  void fixupClonedReferences(const model::ModelObject& original, model::ModelObject clonedObject) {
-    std::map<Handle, model::ModelObject> handleMap;
-    buildCloneHandleMap(original, clonedObject, handleMap);
-    remapLateralReferences(original, clonedObject, handleMap);
-  }
+// `original` is the subtree that was cloned; `clonedObject` is its clone. Re-links any lateral
+// reference in the clone that still points into (or should point into) the original subtree.
+void fixupClonedReferences(const model::ModelObject& original, model::ModelObject clonedObject) {
+  std::map<Handle, model::ModelObject> handleMap;
+  buildCloneHandleMap(original, clonedObject, handleMap);
+  remapLateralReferences(original, clonedObject, handleMap);
+}
 }  // namespace
 
 void HVACLayoutController::addLibraryObjectToModelNode(const OSItemId& itemId, model::HVACComponent& comp) {

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -10,6 +10,8 @@ set(${target_name}_src
   ${CMAKE_CURRENT_BINARY_DIR}/OpenStudioApplicationPathHelpers.cxx
   RemoteBCLNLR.hpp
   RemoteBCLNLR.cpp
+  CloneFixup.hpp
+  CloneFixup.cpp
 )
 
 # set up groups of source files for Visual Studio
@@ -17,6 +19,7 @@ source_group(${target_name} FILES ${target_name}_src)
 
 set(${target_name}_test_src
   test/OpenStudioApplicationPathHelpers_GTest.cpp
+  test/CloneFixup_GTest.cpp
 )
 
 set(${target_name}_depends

--- a/src/utilities/CloneFixup.cpp
+++ b/src/utilities/CloneFixup.cpp
@@ -106,7 +106,7 @@ void remapLateralReferences(const model::ModelObject& original, model::ModelObje
 }
 }  // namespace
 
-void fixupClonedReferences(const model::ModelObject& original, model::ModelObject& clonedObject) {
+void fixupClonedReferences(const model::ModelObject& original, const model::ModelObject& clonedObject) {
   std::vector<std::pair<model::ModelObject, model::ModelObject>> pairs;
   collectClonedObjectPairs(original, clonedObject, pairs);
 

--- a/src/utilities/CloneFixup.cpp
+++ b/src/utilities/CloneFixup.cpp
@@ -1,0 +1,123 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) OpenStudio Coalition and other contributors.
+*  See also https://openstudiocoalition.org/about/software_license/
+***********************************************************************************************************************/
+
+#include "CloneFixup.hpp"
+
+#include <openstudio/model/AirLoopHVACOutdoorAirSystem.hpp>
+#include <openstudio/model/AirLoopHVACOutdoorAirSystem_Impl.hpp>
+#include <openstudio/model/Loop.hpp>
+#include <openstudio/model/Loop_Impl.hpp>
+#include <openstudio/model/ParentObject.hpp>
+#include <openstudio/model/ParentObject_Impl.hpp>
+
+#include <openstudio/utilities/idd/IddObject.hpp>
+#include <openstudio/utilities/idf/Handle.hpp>
+#include <openstudio/utilities/idf/WorkspaceObject.hpp>
+
+#include <boost/functional/hash.hpp>
+
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace openstudio {
+
+namespace {
+// ParentObject::children() is true ownership (e.g. a UnitarySystem's fan/coils) but does *not*
+// include HVACComponents placed on a Loop's supply/demand branches -- a UnitarySystem sitting on
+// an AirLoopHVAC's supply branch is reachable via supplyComponents(), not children(). The same
+// gap exists one level deeper: equipment on an AirLoopHVACOutdoorAirSystem's outdoor-air/relief
+// branches (e.g. an evaporative cooler, or a SetpointManager:MixedAir sitting on one of those
+// nodes) is reachable only via oaComponents()/reliefComponents(), not children() either. Cloning
+// a whole loop (the "copy system" toolbar action) needs all of these, or the branch equipment --
+// and anything lateral-referenced from inside it -- is never visited at all.
+//
+// Returned as separate groups, each matched and recursed into independently: cloning a loop does
+// not carry over the connected thermal zones on the demand side, so original vs. clone
+// demandComponents() can legitimately have different sizes. Treating everything as one combined
+// list would let a benign demand-side mismatch abort recursion into the other groups too, where
+// the equipment (and any lateral references inside it) *does* line up 1:1 with the original.
+std::vector<std::vector<model::ModelObject>> childSubtreeObjectGroups(const model::ModelObject& object) {
+  std::vector<std::vector<model::ModelObject>> groups;
+  if (boost::optional<model::Loop> loop = object.optionalCast<model::Loop>()) {
+    groups.push_back(loop->supplyComponents());
+    groups.push_back(loop->demandComponents());
+  }
+  if (boost::optional<model::AirLoopHVACOutdoorAirSystem> oaSystem = object.optionalCast<model::AirLoopHVACOutdoorAirSystem>()) {
+    groups.push_back(oaSystem->oaComponents());
+    groups.push_back(oaSystem->reliefComponents());
+  }
+  if (boost::optional<model::ParentObject> parent = object.optionalCast<model::ParentObject>()) {
+    groups.push_back(parent->children());
+  }
+  return groups;
+}
+
+// Walks `original` and `clone` in parallel -- childSubtreeObjectGroups() order is deterministic
+// and preserved by clone() -- appending every matched (original, clone) pair in the subtree,
+// including the roots themselves, to `pairs`. A single recursive walk here is shared by both the
+// handle-map build and the reference remap below, rather than each re-implementing it.
+void collectClonedObjectPairs(const model::ModelObject& original, const model::ModelObject& clone,
+                              std::vector<std::pair<model::ModelObject, model::ModelObject>>& pairs) {
+  pairs.emplace_back(original, clone);
+
+  std::vector<std::vector<model::ModelObject>> originalGroups = childSubtreeObjectGroups(original);
+  std::vector<std::vector<model::ModelObject>> cloneGroups = childSubtreeObjectGroups(clone);
+  for (size_t g = 0; g < originalGroups.size() && g < cloneGroups.size(); ++g) {
+    const std::vector<model::ModelObject>& originalChildren = originalGroups[g];
+    const std::vector<model::ModelObject>& cloneChildren = cloneGroups[g];
+    if (originalChildren.size() == cloneChildren.size()) {
+      for (size_t i = 0; i < originalChildren.size(); ++i) {
+        collectClonedObjectPairs(originalChildren[i], cloneChildren[i], pairs);
+      }
+    }
+  }
+}
+
+// For every lateral object-list field on `original` whose target was itself cloned (i.e. has an
+// entry in handleMap), forces the corresponding field on `clonedObject` to point at that clone.
+// Fields are read from `original`, not from `clonedObject`: clone() doesn't necessarily leave a
+// lateral reference pointing at the stale original object -- for CoilHeatingDesuperheater's
+// heatingSource() it clears the field outright -- so the only reliable source of "what this
+// field is supposed to point at" is the original.
+void remapLateralReferences(const model::ModelObject& original, model::ModelObject& clonedObject,
+                            const std::unordered_map<Handle, model::ModelObject, boost::hash<boost::uuids::uuid>>& handleMap) {
+  IddObject iddObject = original.iddObject();
+  for (unsigned index = 0; index < original.numFields(); ++index) {
+    if (iddObject.objectLists(index).empty()) {
+      continue;
+    }
+    boost::optional<WorkspaceObject> originalTarget = original.getTarget(index);
+    if (!originalTarget) {
+      continue;
+    }
+    auto it = handleMap.find(originalTarget->handle());
+    if (it == handleMap.end()) {
+      continue;
+    }
+    boost::optional<WorkspaceObject> clonedTarget = clonedObject.getTarget(index);
+    if (clonedTarget && clonedTarget->handle() == it->second.handle()) {
+      continue;
+    }
+    clonedObject.setPointer(index, it->second.handle());
+  }
+}
+}  // namespace
+
+void fixupClonedReferences(const model::ModelObject& original, model::ModelObject& clonedObject) {
+  std::vector<std::pair<model::ModelObject, model::ModelObject>> pairs;
+  collectClonedObjectPairs(original, clonedObject, pairs);
+
+  std::unordered_map<Handle, model::ModelObject, boost::hash<boost::uuids::uuid>> handleMap;
+  for (const auto& pair : pairs) {
+    handleMap.emplace(pair.first.handle(), pair.second);
+  }
+
+  for (auto& pair : pairs) {
+    remapLateralReferences(pair.first, pair.second, handleMap);
+  }
+}
+
+}  // namespace openstudio

--- a/src/utilities/CloneFixup.hpp
+++ b/src/utilities/CloneFixup.hpp
@@ -22,7 +22,7 @@ namespace openstudio {
 ///
 /// `original` is the subtree that was cloned; `clonedObject` is its clone. Re-links any lateral
 /// reference in the clone that still points into (or should point into) the original subtree.
-void fixupClonedReferences(const model::ModelObject& original, model::ModelObject& clonedObject);
+void fixupClonedReferences(const model::ModelObject& original, const model::ModelObject& clonedObject);
 
 }  // namespace openstudio
 

--- a/src/utilities/CloneFixup.hpp
+++ b/src/utilities/CloneFixup.hpp
@@ -1,0 +1,29 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) OpenStudio Coalition and other contributors.
+*  See also https://openstudiocoalition.org/about/software_license/
+***********************************************************************************************************************/
+
+#ifndef OSAPP_UTILITIES_CLONEFIXUP_HPP
+#define OSAPP_UTILITIES_CLONEFIXUP_HPP
+
+#include <openstudio/model/ModelObject.hpp>
+
+namespace openstudio {
+
+/// ModelObject::clone() clones each child individually and reattaches it via setParent(), so true
+/// parent-child edges are correctly remapped to point within the new subtree. But children are
+/// cloned one at a time rather than as a batch sharing a single old->new handle table, so any
+/// *lateral* object-list reference between two siblings in the cloned subtree (e.g.
+/// CoilHeatingDesuperheater::heatingSource() pointing at a sibling cooling coil, or a
+/// SetpointManager's node references) is left broken on the clone -- for some field/type
+/// combinations still pointing at the original object, for others (empirically, heatingSource())
+/// cleared to empty outright. This fixes that up generically, for any object type, rather than
+/// special casing each lateral-reference field as it's discovered.
+///
+/// `original` is the subtree that was cloned; `clonedObject` is its clone. Re-links any lateral
+/// reference in the clone that still points into (or should point into) the original subtree.
+void fixupClonedReferences(const model::ModelObject& original, model::ModelObject& clonedObject);
+
+}  // namespace openstudio
+
+#endif  // OSAPP_UTILITIES_CLONEFIXUP_HPP

--- a/src/utilities/test/CloneFixup_GTest.cpp
+++ b/src/utilities/test/CloneFixup_GTest.cpp
@@ -1,0 +1,83 @@
+/***********************************************************************************************************************
+*  OpenStudio(R), Copyright (c) OpenStudio Coalition and other contributors.
+*  See also https://openstudiocoalition.org/about/software_license/
+***********************************************************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "../CloneFixup.hpp"
+
+#include <openstudio/model/AirLoopHVAC.hpp>
+#include <openstudio/model/AirLoopHVAC_Impl.hpp>
+#include <openstudio/model/CoilCoolingDXSingleSpeed.hpp>
+#include <openstudio/model/CoilCoolingDXSingleSpeed_Impl.hpp>
+#include <openstudio/model/CoilHeatingDesuperheater.hpp>
+#include <openstudio/model/CoilHeatingDesuperheater_Impl.hpp>
+#include <openstudio/model/Model.hpp>
+#include <openstudio/model/Node.hpp>
+
+using namespace openstudio;
+using namespace openstudio::model;
+
+TEST(CloneFixup, RemapsLateralReferenceOnCloneSubtree) {
+  Model model;
+  AirLoopHVAC airLoopHVAC(model);
+  CoilCoolingDXSingleSpeed coolingCoil(model);
+  CoilHeatingDesuperheater desuperheaterCoil(model);
+  ASSERT_TRUE(desuperheaterCoil.setHeatingSource(coolingCoil));
+
+  Node coolingCoilNode = airLoopHVAC.supplyOutletNode();
+  ASSERT_TRUE(coolingCoil.addToNode(coolingCoilNode));
+  Node desuperheaterNode = airLoopHVAC.supplyOutletNode();
+  ASSERT_TRUE(desuperheaterCoil.addToNode(desuperheaterNode));
+
+  ModelObject original = airLoopHVAC;
+  ModelObject clonedObject = airLoopHVAC.clone(model);
+  fixupClonedReferences(original, clonedObject);
+
+  auto clonedLoop = clonedObject.cast<AirLoopHVAC>();
+  boost::optional<CoilHeatingDesuperheater> clonedDesuperheater;
+  boost::optional<CoilCoolingDXSingleSpeed> clonedCoolingCoil;
+  for (const ModelObject& comp : clonedLoop.supplyComponents()) {
+    if (auto d = comp.optionalCast<CoilHeatingDesuperheater>()) {
+      clonedDesuperheater = d;
+    } else if (auto c = comp.optionalCast<CoilCoolingDXSingleSpeed>()) {
+      clonedCoolingCoil = c;
+    }
+  }
+  ASSERT_TRUE(clonedDesuperheater);
+  ASSERT_TRUE(clonedCoolingCoil);
+
+  // The clone's heatingSource must point at the *cloned* cooling coil, not the original.
+  boost::optional<ModelObject> clonedHeatingSource = clonedDesuperheater->heatingSource();
+  ASSERT_TRUE(clonedHeatingSource);
+  EXPECT_EQ(clonedHeatingSource->handle(), clonedCoolingCoil->handle());
+  EXPECT_NE(clonedHeatingSource->handle(), coolingCoil.handle());
+
+  // The original must be untouched.
+  boost::optional<ModelObject> originalHeatingSource = desuperheaterCoil.heatingSource();
+  ASSERT_TRUE(originalHeatingSource);
+  EXPECT_EQ(originalHeatingSource->handle(), coolingCoil.handle());
+}
+
+TEST(CloneFixup, NoLateralReferenceIsANoOp) {
+  Model model;
+  AirLoopHVAC airLoopHVAC(model);
+  CoilCoolingDXSingleSpeed coolingCoil(model);
+
+  Node coolingCoilNode = airLoopHVAC.supplyOutletNode();
+  ASSERT_TRUE(coolingCoil.addToNode(coolingCoilNode));
+
+  ModelObject original = airLoopHVAC;
+  ModelObject clonedObject = airLoopHVAC.clone(model);
+  EXPECT_NO_THROW(fixupClonedReferences(original, clonedObject));
+
+  auto clonedLoop = clonedObject.cast<AirLoopHVAC>();
+  bool foundClonedCoil = false;
+  for (const ModelObject& comp : clonedLoop.supplyComponents()) {
+    if (comp.optionalCast<CoilCoolingDXSingleSpeed>()) {
+      foundClonedCoil = true;
+    }
+  }
+  EXPECT_TRUE(foundClonedCoil);
+}


### PR DESCRIPTION
## Summary
- Adds "Unitary - Single Speed DX cooling - Elec heat - CAV - Desuperheater reheat" to the default HVAC library: the existing single-speed DX cooling coil paired with a new `Coil:Heating:Desuperheater` as the supplemental/reheat coil under `CoolReheat` dehumidification control, so reheat is partially sourced from the cooling coil's waste heat instead of just resistance heat.
- Fixes `AirLoopHVACUnitarySystem`/loop cloning (both "drag from library" and "Copy System"): `ModelObject::clone()` only remaps true parent-child relationships. Lateral (sibling-to-sibling) object-list references — like `CoilHeatingDesuperheater::heatingSource()`, or a `SetpointManager:MixedAir`'s node fields — are left broken on the clone, sometimes stale, sometimes cleared outright. Added a generic post-clone reference fixup (`buildCloneHandleMap` + `remapLateralReferences` in `HVACSystemsController.cpp`, using `IddObject::objectLists()`/`WorkspaceObject::getTarget()`/`setPointer()`) rather than a Desuperheater-specific special case.
- The traversal walks `children()`, a loop's `supplyComponents()`/`demandComponents()`, and an outdoor air system's `oaComponents()`/`reliefComponents()` as independently size-matched groups, since branch equipment (units on a loop, or equipment like an evaporative cooler on an OA system's branches) isn't reachable via `children()` alone, and demand-side counts can legitimately differ between original and clone since connected thermal zones are never duplicated.

## Context
Modeling dehumidification via hot-gas/desuperheater reheat is a recurring real-world need — see [this UnmetHours thread](https://unmethours.com/question/103316/how-to-make-coilcoolingdxtwostagewithhumiditycontrolmode-work/), where `CoilCoolingDXTwoStageWithHumidityControlMode` proved awkward to control directly and commenters pointed toward `Coil:Heating:Desuperheater` as a workaround. Worth noting the thread's caveat: a desuperheater coil reclaims waste heat from the refrigerant's superheat and doesn't affect compressor performance, so it's a lower-fidelity approximation of "true" hot-gas reheat, not an exact substitute — but it's a standard, supported EnergyPlus object and a reasonable default-library addition for this use case.

## Proof this was broken before this fix
You don't need the new desuperheater system to see the underlying bug — it reproduces with a completely stock model:
1. In the app, `File > Examples > Example Model` to generate a fresh example model.
2. Go to the HVAC Systems tab, select the one airloop, click "Copy System."
3. Select the copy and open its outdoor air system. It has an evaporative cooler with a `SetpointManager:MixedAir` attached — but on the *copy*, that setpoint manager's Reference Setpoint / Fan Inlet / Fan Outlet Node fields are all empty (shown as warning icons in the inspector), even though the original's are filled in correctly.
4. Run a simulation on the copy: EnergyPlus fails immediately with a fatal error (missing required properties on that object) before any calculation happens.

That's `ModelObject::clone()`'s lateral-reference bug on a totally unmodified example model — this PR's fixup resolves it for both this stock case and the new desuperheater system.

## Test plan
- [x] `cmake --build . --target openstudio_lib --config Release` succeeds
- [x] Dragged the new system onto a zone in the app and ran the simulation successfully
- [x] Used "Copy System" on that airloop, reassigned zones on the copy, and ran the simulation successfully
- [x] Verified against the SDK directly (Ruby) for same-model/cross-model clone scenarios, and against `OpenStudio::Model.exampleModel`'s stock outdoor-air-system evaporative cooler + `SetpointManager:MixedAir`
- [x] Confirmed live in the rebuilt app that "Copy System" correctly re-wires node references on that stock example airloop too